### PR TITLE
Add mds combobox

### DIFF
--- a/Macros/SheetMetalUnfoldUpdater.FCMacro
+++ b/Macros/SheetMetalUnfoldUpdater.FCMacro
@@ -62,10 +62,13 @@ for o in doc.Objects:
 							# This view uses our unfolded output, update this view at the end 
 							echo("* Found related TechDraw ProjGroup: %s\n" % view.Label)
 							related_views.append(view)
-							
+			
+			# mark current output as "to be deleted"
+			tmp_postfix = "_TMP"
+			old = None		
 			try:
-				old = doc.getObjectsByLabel(output_name)[0].Name
-				doc.removeObject(old)
+				old = doc.getObjectsByLabel(output_name)[0]
+				old.Label += tmp_postfix
 				doc.recompute()
 			except:
 				pass
@@ -82,22 +85,35 @@ for o in doc.Objects:
 			Gui.Selection.clearSelection()
 			Gui.Selection.addSelection(doc.Name, unfold_face_id[0], unfold_face_id[1])
 			Gui.runCommand('SMUnfoldUnattended')
-			
-			# Remove unnecessary unfolded solid
-			doc.removeObject('Unfold')
-			
-			# Properly rename the output
-			sketch = doc.getObjectsByLabel('Unfold_Sketch')[0]
-			sketch.Label = output_name
-			sketch.Visibility = False
-			
-			# Update the source of related views
-			if len(related_views) > 0:
-				for view in related_views:
-					echo("* Updating %s source as %s\n" % (view.Label, sketch.Label))
-					view.Source = [sketch]
-			else:
-				warn('No TechDraw view is updated.\n')
+		
+			try:
+				# Remove unnecessary unfolded solid
+				doc.removeObject('Unfold')
+				
+				# Properly rename the output
+				sketch = doc.getObjectsByLabel('Unfold_Sketch')[0]
+				sketch.Label = output_name
+				sketch.Visibility = False
+				
+				# Update the source of related views
+				if len(related_views) > 0:
+					for view in related_views:
+						echo("* Updating %s source as %s\n" % (view.Label, sketch.Label))
+						view.Source = [sketch]
+				else:
+					warn('No TechDraw view is updated.\n')
+
+				# remove the temporary object
+				if old is not None:
+					doc.removeObject(old.Name)
+					doc.recompute()
+			except:
+				warn('Something went wrong.\n')
+				# restore the previous sketch
+				if old is not None:
+					echo("* Restoring the previous sketch.\n")
+					old.Label = old.Label[:-(len(tmp_postfix))]
+					doc.recompute()
 
 doc.recompute()
 Gui.Selection.clearSelection()

--- a/Macros/SheetMetalUnfoldUpdater.FCMacro
+++ b/Macros/SheetMetalUnfoldUpdater.FCMacro
@@ -54,8 +54,6 @@ for o in doc.Objects:
 						try: 
 							_src = view.Source[0]
 						except Exception as e:
-							warn("!! Exception of %s is: %s" % (view.Label, e.args[0]))
-							print(view.Source)
 							continue
 						#print "source of ", view.Label, ' in ', x.Label, " is: ", _src.Label
 						if _src.Label == output_name:

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ To use the Material Definition Sheet, follow the steps:
 3. Create a spreadsheet with the name of `material_foo`
 4. Create a table layout in `material_foo`, like the following (see [this table](https://user-images.githubusercontent.com/6639874/56498031-b017bc00-6508-11e9-8b14-6076513d8488.png)): 
 
-    | Radius / Thickness | K-factor | Options | | 
-    | ---| ---| --- | --- |
-    | 1 | 0.38 | K-factor standard | ANSI |
-    | 3 | 0.43 | | |
-    | 99 | 0.5 | | |
+    | Radius / Thickness | K-factor | | Options | | 
+    | ---| ---| --- | --- | --- |
+    | 1 | 0.38 | | K-factor standard | ANSI |
+    | 3 | 0.43 | | | |
+    | 99 | 0.5 | | | |
     
     Notes: 
     

--- a/README.md
+++ b/README.md
@@ -35,14 +35,12 @@ You can use a Spreadsheet object to declare K-factor values inside the project f
 
 * Different K-factor values to be used for each bend in your model 
 * Sharing the same material definition for multiple objects 
-* Unattended unfold (required for ["Unfold Updater" macro](./Macros/SheetMetalUnfoldUpdater.FCMacro))
 
 To use the Material Definition Sheet, follow the steps:
 
 1. Determine your material name (eg. `foo`)
-2. Add `_material_foo` postfix to your shape's Label.
-3. Create a spreadsheet with the name of `material_foo`
-4. Create a table layout in `material_foo`, like the following (see [this table](https://user-images.githubusercontent.com/6639874/56498031-b017bc00-6508-11e9-8b14-6076513d8488.png)): 
+2. Create a spreadsheet with the name of `material_foo`
+3. Create a table layout in `material_foo`, like the following (see [this table](https://user-images.githubusercontent.com/6639874/56498031-b017bc00-6508-11e9-8b14-6076513d8488.png)):
 
     | Radius / Thickness | K-factor | | Options | | 
     | ---| ---| --- | --- | --- |
@@ -56,6 +54,7 @@ To use the Material Definition Sheet, follow the steps:
     2. Possible values for `K-factor standard` is `ANSI` or `DIN`. 
     3. `Radius / Thickness` means `Radius over Thickness`. Eg. if inner radius is `1.64mm` and material thickness is `2mm` then `Radius / Thickness == 1.64/2 = 0.82` so `0.38` will be used as the K-factor. See [lookup.py](https://github.com/ceremcem/FreeCAD_SheetMetal/blob/k-factor-from-lookup/lookup.py#L46-L68) for more examples.
 
+4. Use "Unfold Task Panel" to assign the material sheet.
 5. Unfold as usual.
 
 [Here](https://user-images.githubusercontent.com/6639874/56642679-a749f600-6680-11e9-944a-82e447d9dc4e.gif) is a screencast in action.

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2153,7 +2153,6 @@ if pg.IsEmpty():
     pg.SetString("bendColor","#c00000")
     pg.SetString("genColor","#000080")
     pg.SetString("intColor","#ff5733")
-    pg.SetBool("persistentManualKfact", 0)
     pg.SetString("manualKFactor", "0.40")
 
 class QColorButton(QtGui.QPushButton):
@@ -2359,7 +2358,10 @@ class SMUnfoldTaskPanel:
         sizePolicy.setHeightForWidth(self.checkKfact.sizePolicy().hasHeightForWidth())
         self.checkKfact.setSizePolicy(sizePolicy)
         self.checkKfact.setObjectName(_fromUtf8("checkKfact"))
+        # NOTE: use `.clicked.connect` instead of `.stateChanged.connect` if you want to
+        # implement a "rollback" feature
         self.checkKfact.stateChanged.connect(self.checkKfactChange)
+        # END OF NOTE
         self.horizontalLayout.addWidget(self.checkKfact)
         spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
         self.horizontalLayout.addItem(spacerItem)
@@ -2407,11 +2409,6 @@ class SMUnfoldTaskPanel:
         self.verticalLayout.addLayout(self.horizontalLayout_2)
         spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         self.verticalLayout.addItem(spacerItem)
-        self.checkPersistentManualKfact = QtGui.QCheckBox(SMUnfoldTaskPanel)
-        self.checkPersistentManualKfact.setObjectName(_fromUtf8("checkPersistentManualKfact"))
-        self.checkPersistentManualKfact.clicked.connect(self.checkPersistentManualKfactClicked)
-        self.verticalLayout.addWidget(self.checkPersistentManualKfact)
-
         self.verticalLayout_2.addLayout(self.verticalLayout)
 
         if genSketchChecked:
@@ -2427,45 +2424,6 @@ class SMUnfoldTaskPanel:
         self.checkSketchChange()
         self.populateMdsList()
         self.retranslateUi()
-
-        self.checkPersistentManualKfact.setChecked(self.pg.GetBool("persistentManualKfact"))
-        if self.checkPersistentManualKfact.isChecked():
-            # check manual K-factor unless MDS is in use
-            if not self.checkUseMds.isChecked():
-                self.checkKfact.setChecked(True)
-
-        #self.grid = QtGui.QGridLayout(self.form)
-        #self.grid.setObjectName("grid")
-        #self.title = QtGui.QLabel(self.form)
-        #self.grid.addWidget(self.title, 0, 0, 1, 2)
-        #self.title.setText("Select a starting face and press OK")
-
-        # options
-        #self.genSketch = QtGui.QCheckBox(self.form)
-        #self.grid.addWidget(self.genSketch, 1, 0, 1, 2)
-        #self.genSketch.setText("Generate Sketch")
-        #if genSketchChecked:
-        #  self.genSketch.setCheckState(QtCore.Qt.CheckState.Checked)
-
-    def checkPersistentManualKfactClicked(self):
-        curr = self.checkPersistentManualKfact.isChecked()
-
-        if curr:
-          msg = "Using 'Manual K-factor' by default is dangerous and may lead you\n"
-          msg += "human errors. Use this setting only if you know what you are doing.\n"
-          msg += "\n"
-          msg += "Are you sure you want to use Manual K-factor by default?"
-          mw = FreeCADGui.getMainWindow()
-          ans = QtGui.QMessageBox.question(mw, "Dangerous Setting", msg,
-                                           QtGui.QMessageBox.Ok, QtGui.QMessageBox.Cancel)
-
-          if ans == QtGui.QMessageBox.Cancel:
-            self.checkPersistentManualKfact.setChecked(False)
-            return
-          else:
-            QtGui.QMessageBox.question(mw, "Warning", "You have been warned.")
-
-        self.checkPersistentManualKfact.setChecked(curr)
 
     def isAllowedAlterSelection(self):
         return True
@@ -2550,9 +2508,6 @@ class SMUnfoldTaskPanel:
             pg.SetBool("genSketch",1)
         else:
             pg.SetBool("genSketch",0)
-
-        # TODO: issue an "are you sure" question
-        pg.SetBool("persistentManualKfact", self.checkPersistentManualKfact.isChecked())
 
         pg.SetString("bendColor",bendSketchColor)
         pg.SetString("genColor",genSketchColor)
@@ -2775,7 +2730,7 @@ class SMUnfoldTaskPanel:
         if not checked and not self.checkUseMds.isChecked():
             # not allowed to uncheck unless "Use MDS" box is checked
             # (radio-button behavior)
-            # FIXME: NOT WORKING! Why? -> self.checkKfact.setChecked(True)
+            # FIXME: NOT WORKING! Why? >>See .clicked.connect note<< -> self.checkKfact.setChecked(True)
             # return 
             pass
         self.kFactSpin.setEnabled(checked)
@@ -2805,7 +2760,6 @@ class SMUnfoldTaskPanel:
         self.kfactorDin.setText(_translate("SheetMetal", "DIN", None))
         self.checkUseMds.setText(_translate("SMUnfoldTaskPanel", "Use Material Definition Sheet", None))
         self.mdsApply.setText(_translate("SMUnfoldTaskPanel", "Apply", None))
-        self.checkPersistentManualKfact.setText(_translate("SMUnfoldTaskPanel", "Use \"Manual K-factor\" unless MDS is in use", None))
 
 
 class SMUnfoldCommandClass():

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2409,6 +2409,7 @@ class SMUnfoldTaskPanel:
         self.verticalLayout.addItem(spacerItem)
         self.checkPersistentManualKfact = QtGui.QCheckBox(SMUnfoldTaskPanel)
         self.checkPersistentManualKfact.setObjectName(_fromUtf8("checkPersistentManualKfact"))
+        self.checkPersistentManualKfact.clicked.connect(self.checkPersistentManualKfactClicked)
         self.verticalLayout.addWidget(self.checkPersistentManualKfact)
 
         self.verticalLayout_2.addLayout(self.verticalLayout)
@@ -2445,7 +2446,27 @@ class SMUnfoldTaskPanel:
         #self.genSketch.setText("Generate Sketch")
         #if genSketchChecked:
         #  self.genSketch.setCheckState(QtCore.Qt.CheckState.Checked)
-        
+
+    def checkPersistentManualKfactClicked(self):
+        curr = self.checkPersistentManualKfact.isChecked()
+
+        if curr:
+          msg = "Using 'Manual K-factor' by default is dangerous and may lead you\n"
+          msg += "human errors. Use this setting only if you know what you are doing.\n"
+          msg += "\n"
+          msg += "Are you sure you want to use Manual K-factor by default?"
+          mw = FreeCADGui.getMainWindow()
+          ans = QtGui.QMessageBox.question(mw, "Dangerous Setting", msg,
+                                           QtGui.QMessageBox.Ok, QtGui.QMessageBox.Cancel)
+
+          if ans == QtGui.QMessageBox.Cancel:
+            self.checkPersistentManualKfact.setChecked(False)
+            return
+          else:
+            QtGui.QMessageBox.question(mw, "Warning", "You have been warned.")
+
+        self.checkPersistentManualKfact.setChecked(curr)
+
     def isAllowedAlterSelection(self):
         return True
 

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2557,13 +2557,21 @@ class SMUnfoldTaskPanel:
                     options_cell = cell 
                 if key_cell is not None and value_cell is not None and options_cell is not None:
                     break 
-            
+
+            lookup_sheet_err = None
             if key_cell is None:
-                raise ValueError("No cell can be found with name: 'Radius / Thickness'")
+                lookup_sheet_err = "No cell can be found with name: 'Radius / Thickness'"
             if value_cell is None:
-                raise ValueError("No cell can be found with name: 'K-factor'")
+                lookup_sheet_err = "No cell can be found with name: 'K-factor'"
             if options_cell is None:
-                raise ValueError("No cell can be found with name: 'Options'")
+                lookup_sheet_err = "No cell can be found with name: 'Options'"
+
+            if lookup_sheet_err is not None:
+                lookup_sheet_err += '\n\n'
+                lookup_sheet_err += "Check your Material Definition Sheet's contents.\n"
+                lookup_sheet_err += "Refer to SheetMetal/README if you are unsure what to do."
+                SMErrorBox(lookup_sheet_err)
+                return
 
             [key_column_name, key_column_row] = get_cell_tuple(key_cell)
             value_column_name = get_cell_tuple(value_cell)[0]

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2840,6 +2840,7 @@ class SMUnfoldUnattendedCommandClass():
     taskd.bendColor.setColor(pg.GetString("bendColor"))
     taskd.genColor.setColor(pg.GetString("genColor"))
     taskd.internalColor.setColor(pg.GetString("intColor"))
+    taskd.new_mds_name = taskd.material_sheet_name
     taskd.accept()
     return
 

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2227,6 +2227,17 @@ def getObjectsByLabelRecursive(doc, label):
     res = objects[0]
   return res
 
+def findObjectsByTypeRecursive(doc, type):
+  objects = []
+  for obj in doc.findObjects():
+    if obj.TypeId == type:
+      objects.append(obj)
+    elif obj.TypeId == 'App::Link':
+      for _o in get_linked_objs_recursive([obj]):
+        if _o.TypeId == type:
+          objects.append(_o)
+  return objects 
+
 # Start of spreadsheet functions
 cell_regex = re.compile('^([A-Z]+)([0-9]+)$')
 def get_cells(sheet):
@@ -2265,13 +2276,7 @@ class SMUnfoldTaskPanel:
             mds_postfix = "_" + self.material_sheet_name
             self.root_label = self.root_label[:-len(mds_postfix)]
 
-        doc = FreeCAD.ActiveDocument
-        # FIXME: "Spreadsheet::Sheet" isn't recognized as a valid type thus thrown an exception
-        # when there is no spreadsheet in the document. This seems like an upstream FC bug.
-        try:
-            spreadsheets = doc.findObjects('Spreadsheet::Sheet')
-        except:
-            spreadsheets = []
+        spreadsheets = findObjectsByTypeRecursive(FreeCAD.ActiveDocument, 'Spreadsheet::Sheet')
         self.availableMdsObjects = [o for o in spreadsheets if material_sheet_regex.match(o.Label)]
                         
         self.obj = None

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2266,7 +2266,13 @@ class SMUnfoldTaskPanel:
             self.root_label = self.root_label[:-len(mds_postfix)]
 
         doc = FreeCAD.ActiveDocument
-        self.availableMdsObjects = [o for o in doc.findObjects('Spreadsheet::Sheet') if material_sheet_regex.match(o.Label)]
+        # FIXME: "Spreadsheet::Sheet" isn't recognized as a valid type thus thrown an exception
+        # when there is no spreadsheet in the document. This seems like an upstream FC bug.
+        try:
+            spreadsheets = doc.findObjects('Spreadsheet::Sheet')
+        except:
+            spreadsheets = []
+        self.availableMdsObjects = [o for o in spreadsheets if material_sheet_regex.match(o.Label)]
                         
         self.obj = None
         self.form = SMUnfoldTaskPanel = QtGui.QWidget()
@@ -2649,6 +2655,7 @@ class SMUnfoldTaskPanel:
             s = None
             QtGui.QApplication.restoreOverrideCursor()
             SMError(e.args)
+            import traceback; traceback.print_exc()
             msg = """Unfold is failing.<br>Please try to select a different face to unfold your object"""
             QtGui.QMessageBox.question(None,"Warning",msg,QtGui.QMessageBox.Ok)
         if (s is not None):

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -180,7 +180,13 @@ def SMErrorBox(* args):
     for x in args:
         message += str(x)
     SMError(message)
-    QtGui.QMessageBox.critical(FreeCADGui.getMainWindow(), "ERROR", message)
+    mw = FreeCADGui.getMainWindow()
+    msg_box = QtGui.QMessageBox(mw)
+    msg_box.setTextFormat(QtCore.Qt.TextFormat.RichText)
+    msg_box.setText(message)
+    msg_box.setWindowTitle("Error")
+    msg_box.setIcon(QtGui.QMessageBox.Critical)
+    msg_box.exec_()
 
 def equal_vertex(vert1, vert2, p=5):
   # compares two vertices 
@@ -2521,6 +2527,8 @@ class SMUnfoldTaskPanel:
         global genSketchChecked, bendSketchChecked, genObjTransparency, manKFactor
         global genSketchColor, bendSketchColor
         global kFactorStandard
+        mds_help_url = "https://github.com/shaise/FreeCAD_SheetMetal#material-definition-sheet"
+
         genSketchChecked = self.checkSketch.isChecked()
         genSketchColor = self.genColor.color()
         bendSketchChecked = self.checkSeparate.isChecked()
@@ -2596,9 +2604,10 @@ class SMUnfoldTaskPanel:
                 lookup_sheet_err = "No cell can be found with name: 'Options'"
 
             if lookup_sheet_err is not None:
-                lookup_sheet_err += '\n\n'
-                lookup_sheet_err += "Check your Material Definition Sheet's contents.\n"
-                lookup_sheet_err += "Refer to SheetMetal/README if you are unsure what to do."
+                lookup_sheet_err += '<p>'
+                lookup_sheet_err += "Check your Material Definition Sheet's contents.<br />"
+                lookup_sheet_err += "Refer to <a href='%s'>SheetMetal/README</a> if you are unsure about how to continue." % mds_help_url
+                lookup_sheet_err += "</p>"
                 SMErrorBox(lookup_sheet_err)
                 return
 
@@ -2654,9 +2663,10 @@ class SMUnfoldTaskPanel:
             SMMessage("Obtained K-factor lookup table is:", k_factor_lookup)
         elif not self.checkKfact.isChecked():
             msg = "Unfold operation needs to know K-factor value(s) to be used."
-            msg += "\n\n"
-            msg += "* Either set a manual K-factor in the SheetMetal options menu\n"
-            msg += "* Or use a \"Material Definition Sheet\" (see SheetMetal/README)"
+            msg += "<ol>"
+            msg += "<li>Either set a Manual K-factor</li>"
+            msg += "<li>Or use a <a href='%s'>Material Definition Sheet</a></li>" % mds_help_url
+            msg += "</ol>"
             SMErrorBox(msg)
             return
         else:

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2284,7 +2284,7 @@ class SMUnfoldTaskPanel:
                   "kfactor": float(virtual_material_match.group(1)),
                   "standard": virtual_material_match.group(2)
                 }
-                SMMessage("This is a Manual K-factor", virtual_material)
+                #SMMessage("This is a Manual K-factor", virtual_material)
 
         spreadsheets = findObjectsByTypeRecursive(FreeCAD.ActiveDocument, 'Spreadsheet::Sheet')
         self.availableMdsObjects = [o for o in spreadsheets if material_sheet_regex.match(o.Label)]

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2553,7 +2553,7 @@ class SMUnfoldTaskPanel:
             pg.SetString("kFactorStandard", kFactorStandard)
             manKFactor = self.kFactSpin.value()
             self.pg.SetString('manualKFactor', str(manKFactor))
-            SMMessage('Manual K-factor is being used: %.2f (%s)', (manKFactor, kFactorStandard))
+            SMMessage('Manual K-factor is being used: %.2f (%s)' % (manKFactor, kFactorStandard))
             self.setMds(self.getManualKFactorString(manKFactor, kFactorStandard))
         else:
             manKFactor = None

--- a/UnfoldOptions.ui
+++ b/UnfoldOptions.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMaximumSize</enum>
+     </property>
      <item>
       <widget class="QCheckBox" name="checkSketch">
        <property name="text">
@@ -182,6 +185,13 @@
         </size>
        </property>
       </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkPersistentManualKfact">
+       <property name="text">
+        <string>Use &quot;Manual K-factor&quot; unless MDS is in use</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/UnfoldOptions.ui
+++ b/UnfoldOptions.ui
@@ -186,13 +186,6 @@
        </property>
       </spacer>
      </item>
-     <item>
-      <widget class="QCheckBox" name="checkPersistentManualKfact">
-       <property name="text">
-        <string>Use &quot;Manual K-factor&quot; unless MDS is in use</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>

--- a/UnfoldOptions.ui
+++ b/UnfoldOptions.ui
@@ -35,6 +35,19 @@
        <item>
         <widget class="QComboBox" name="availableMds"/>
        </item>
+       <item>
+        <widget class="QPushButton" name="mdsApply">
+         <property name="maximumSize">
+          <size>
+           <width>50</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Apply</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>

--- a/UnfoldOptions.ui
+++ b/UnfoldOptions.ui
@@ -24,6 +24,20 @@
       </widget>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="materalDefinitionSheetLayout">
+       <item>
+        <widget class="QCheckBox" name="checkUseMds">
+         <property name="text">
+          <string>Use Material Definition Sheet</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="availableMds"/>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="sizeConstraint">
         <enum>QLayout::SetDefaultConstraint</enum>


### PR DESCRIPTION
Related to #78 

![image](https://user-images.githubusercontent.com/6639874/56850891-42f19580-6911-11e9-8cf1-e2ee92933643.png)

Now users are able to: 
* List available Material Definition Sheets by the combobox. 
* Set any available MDS as well as remove the current MDS assignment. 

# Changelog 

* Added Material Definition Sheet selection combobox to the Unfold Task Panel. 
* Improved error outputs 

# Is breaking?

Nope. 