### PR TITLE
Fix #113 'Bug in "Create a sheetmetal wall from a sketch" wrong radius for open sketches'

### DIFF
--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -69,7 +69,7 @@ def smBase(thk = 2.0, length = 10.0, radius = 1.0, Side = "Inside", MainObject =
       else :
         wire = WireList
       #Part.show(wire)
-      filletedWire = DraftGeomUtils.filletWire(wire, (radius * 1.5) )
+      filletedWire = DraftGeomUtils.filletWire(wire, (radius + thk / 2) )
       #Part.show(filletedWire)
       offsetwire = filletedWire.makeOffset2D(thk/2.0, openResult = True )
       #Part.show(offsetwire)


### PR DESCRIPTION
The small radius should be `radius`, then the big radius should be `radius * 2`. Since the boundaries are obtained by offseting the middle sketch, then the right radius should the in between : `(radius + radius + thk) / 2 = radius + thk / 2`