### PR TITLE
Manually coerce thickness to str before concatenating

### DIFF
--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -518,7 +518,7 @@ class SheetTree(object):
         if (self.__thickness < estimated_thickness) or (self.__thickness > 1.9 * estimated_thickness):
           self.error_code = 3
           self.failed_face_idx = f_idx
-          FreeCAD.Console.PrintLog("estimated thickness: " + str(estimated_thickness) + " measured thickness: " + self.__thickness + "\n")
+          FreeCAD.Console.PrintLog("estimated thickness: " + str(estimated_thickness) + " measured thickness: " + str(self.__thickness) + "\n")
           Part.show(lLine, 'Measurement_Thickness_trial')
 
 


### PR DESCRIPTION
Previously I saw errors of the form:
```
Material found: 0.40ansi
Manual K-factor is being used: 0.40 (ansi)
exception at line 2838('can only concatenate str (not "float") to str',)
('can only concatenate str (not "float") to str',)
Traceback (most recent call last):
  File "/home/ben/.FreeCAD/Mod/sheetmetal/SheetMetalUnfolder.py", line 2838, in accept
    s, foldComp, norm, thename, err_cd, fSel, obN  = getUnfold(k_factor_lookup)
  File "/home/ben/.FreeCAD/Mod/sheetmetal/SheetMetalUnfolder.py", line 2166, in getUnfold
    TheTree = SheetTree(o.Object.Shape, f_number, k_factor_lookup) # initializes the tree-structure
  File "/home/ben/.FreeCAD/Mod/sheetmetal/SheetMetalUnfolder.py", line 521, in __init__
    FreeCAD.Console.PrintLog("estimated thickness: " + str(estimated_thickness) + " measured thickness: " + self.__thickness + "\n")
TypeError: can only concatenate str (not "float") to str
```