### PR TITLE
keeping Sketch Name as Sketch Label

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -33,7 +33,7 @@ smWB_icons_path =  os.path.join( smWBpath, 'Resources', 'icons')
 global main_smWB_Icon
 main_smWB_Icon = os.path.join( smWB_icons_path , 'SMLogo.svg')
 
-SHEETMETALWB_VERSION = 'V0.2.42'
+SHEETMETALWB_VERSION = 'V0.2.43'
 
 class SMWorkbench (Workbench):
  

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2974,7 +2974,7 @@ class SMUnfoldTaskPanel:
         docG = FreeCADGui.ActiveDocument
         p = Part.makeCompound(edges)
         try:
-            sk = Draft.makeSketch(p.Edges, autoconstraints = True)
+            sk = Draft.makeSketch(p.Edges, autoconstraints = True,addTo=None,delete=False,name=name)
             sk.Label = name
         except:
             doc = FreeCAD.ActiveDocument


### PR DESCRIPTION
keeping Sketch Name as Sketch Label, useful to have meaningful names when exporting the sketches to DXF