### PR TITLE
Extended Material Definition Sheet name matching RegEx pattern.

### DIFF
--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -2425,7 +2425,7 @@ class SMUnfoldTaskPanel:
 
         # Get the material name if possible
         self.material_sheet_name = None
-        material_sheet_regex_str = "material_([a-zA-Z0-9_\.]+)"
+        material_sheet_regex_str = "material_([a-zA-Z0-9_\-\[\]\.]+)"
         material_sheet_regex = re.compile(material_sheet_regex_str)
         material_regex = re.compile(".+_%s" % material_sheet_regex_str)
         self.root_obj = self.get_root_obj()


### PR DESCRIPTION
It wasn't matching with a name like `material_al5754h111_batch1[-]`. This is fixed. 