### PR TITLE
Import os.path in InitGui.py Initialize function

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -58,6 +58,7 @@ class SMWorkbench (Workbench):
         import SheetMetalRelief
         import SheetMetalJunction
         import SheetMetalBend
+        import os.path
         self.list = ["SMBase", "SMMakeWall", "SMExtrudeFace", "SMFoldWall", "SMUnfold", "SMMakeRelief", "SMMakeJunction", "SMMakeBend"] # A list of command names created in the line above
         if engineering_mode_enabled(): 
             self.list.insert(self.list.index("SMUnfold") + 1,"SMUnfoldUnattended")


### PR DESCRIPTION
When using the workbench on FreeCAD 0.18.4 Linux AppImage, this error
prevents it from loading:

```
name 'os' is not defined
Traceback (most recent call last):
  File "<string>", line 67, in Initialize
```

I have no idea why the global import added in commit 206bd12 doesn't
work, but I tried several different things, and this change fixed the
error for me.

This (re) fixes #138