### PR TITLE
Remove version number appended to Sheet Metal wb name in menu dropdown

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -34,8 +34,6 @@ smWB_icons_path =  os.path.join( smWBpath, 'Resources', 'icons')
 global main_smWB_Icon
 main_smWB_Icon = os.path.join( smWB_icons_path , 'SMLogo.svg')
 
-SHEETMETALWB_VERSION = 'V0.2.49'
-
 class SMWorkbench (Workbench):
 
     global main_smWB_Icon
@@ -45,7 +43,7 @@ class SMWorkbench (Workbench):
     global smWBpath
     global smWB_icons_path
 
-    MenuText = 'Sheet Metal '+SHEETMETALWB_VERSION
+    MenuText = 'Sheet Metal'
     ToolTip = QtCore.QT_TRANSLATE_NOOP('SheetMetal','Sheet Metal workbench allows for designing and unfolding sheet metal parts')
     Icon = main_smWB_Icon
 


### PR DESCRIPTION
This has been made obsolete by the new addon manager functionality that lists version info from package.xml in the About info dialog. Also it breaks uniformity esthetics with other workbench names + can be problematic with some themes like ModernUI, see example:

![image](https://user-images.githubusercontent.com/4140247/162287127-62374ac2-0a6f-4b9b-b980-5b37d1ce9d8b.png)
