### PR TITLE
Correct classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
 
   <content>
     <workbench>
-      <classname>SheetMetalWorkbench</classname>
+      <classname>SMWorkbench</classname>
       <subdirectory>./</subdirectory>
       <tag>sheetmetal</tag>
     </workbench>


### PR DESCRIPTION
You actually used `SMWorkbench` as your class in `InitGui.py`, so this updates package.xml to find it correctly.