### PR TITLE
moving from Drawing to TechDraw FC0.21 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Starting from FreeCAD 0.17 it can be installed via the [Addon Manager](https://g
 * FreeCAD Forum announcement/discussion [thread](https://forum.freecadweb.org/viewtopic.php?f=3&t=60818) 
 
 #### Release notes:
+* V0.2.50 09 Jul 2022:  Moved 'Drawing' to 'TechDraw' for FC0.21 compatibility. Thank you!
 * V0.2.49 03 Jul 2021:  Add SubShapeBinder as source by [@s-light][s-light]. Thank you!
 * V0.2.48 02 May 2021:  Add context menu [@jaisejames][jaisejames]. Thank you!
 * V0.2.47 24 Feb 2021:  Add translation support by [@jaisejames][jaisejames]. Thank you!

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -103,7 +103,7 @@ from FreeCAD import Base
 from FreeCAD import Gui
 import DraftVecUtils, math, time
 import Draft
-import Drawing
+import TechDraw
 from lookup import get_val_from_range
 from engineering_mode import engineering_mode_enabled
 
@@ -2896,11 +2896,11 @@ class SMUnfoldTaskPanel:
           a.Shape = s
           if genSketchChecked:
             edges = []
-            grp1 = Drawing.projectEx(s,norm)
+            grp1 = TechDraw.projectEx(s,norm)
             edges.append(grp1[0])
             if len(foldLines) > 0:
               co = Part.makeCompound(foldLines)
-              grp2 = Drawing.projectEx(co, norm)
+              grp2 = TechDraw.projectEx(co, norm)
               if not bendSketchChecked:
                 edges.append(grp2[0])
             self.generateSketch(edges, "Unfold_Sketch", self.genColor.colorF())

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>SheetMetal Workbench</name>
   <description>A simple sheet metal tools workbench for FreeCAD.</description>
-  <version>0.2.49</version>
-  <date>2021-07-03</date>
+  <version>0.2.50</version>
+  <date>2022-07-09</date>
   <maintainer email="shaise@gmail.com">Shai Seger</maintainer>
   <license file="LICENSE">GPLv3</license>
   <url type="repository" branch="master">https://github.com/shaise/FreeCAD_SheetMetal</url>


### PR DESCRIPTION
Since recently 'Drawing' has been deprecated (disabled) in FC main 0.21+,
this PR will switch the calls using Drawing to TechDraw, keeping SheetMetal fully functional both in FC stable and daily