### PR TITLE
SM: Fix smExtrude for cylindrical connecting faces

### DIFF
--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -212,7 +212,9 @@ def smExtrude(extLength = 10.0, gap1 = 0.0, gap2 = 0.0, subtraction = False, off
 #    MlenEdge = lenEdge
 #    leng = MlenEdge.Length
     revAxisV.normalize()
-    thkDir = Cface.normalAt(0,0) * -1
+    # Get normal of Cface at p1 to correctly handle cylindrical connecting faces
+    params = Cface.Surface.projectPoint(p1, "LowerDistanceParameters")
+    thkDir = Cface.normalAt(params[0], params[1]) * -1
     FaceDir = selFace.normalAt(0,0)
 
     # if sketch is as wall


### PR DESCRIPTION
The `smExtrude` function did not determine the normal of the connecting face at the connecting edge. This could result in a wrong direction for cylindrical connecting faces.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=3&t=70433

Note:
Do not forget to update the version number when merging.