### PR TITLE
SM: Fix getBendetail and smExtrude for non-planar connecting faces

### DIFF
--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -360,10 +360,12 @@ def getBendetail(selFaceNames, MainObject, bendR, bendA, flipped, offset, gap1, 
 
     # main Length Edge
     revAxisV.normalize()
-    thkDir = Cface.normalAt(0,0) * -1
+    pThkDir1 = selFace.CenterOfGravity
+    pThkDir2 = lenEdge.Curve.projectPoint(pThkDir1, "NearestPoint")
+    thkDir = pThkDir1.sub(pThkDir2).normalize()
     FaceDir = selFace.normalAt(0,0)
 
-    #make sure the direction verctor is correct in respect to the normal
+    # make sure the direction vector is correct in respect to the normal
     if (thkDir.cross(revAxisV).normalize() - FaceDir).Length < smEpsilon:
      revAxisV = revAxisV * -1
 
@@ -1394,4 +1396,3 @@ class AddWallCommandClass():
     return True
 
 Gui.addCommand('SMMakeWall',AddWallCommandClass())
-

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -187,7 +187,7 @@ def smExtrude(extLength = 10.0, gap1 = 0.0, gap2 = 0.0, subtraction = False, off
         thk = abs( edge.Length )
         thkEdge = edge
 
-    # find a length edge  =  revolve axis direction
+    # find a length edge
     p0 = thkEdge.valueAt(thkEdge.FirstParameter)
     for lenEdge in selFace.Edges:
       p1 = lenEdge.valueAt(lenEdge.FirstParameter)
@@ -195,10 +195,8 @@ def smExtrude(extLength = 10.0, gap1 = 0.0, gap2 = 0.0, subtraction = False, off
       if lenEdge.isSame(thkEdge):
         continue
       if (p1 - p0).Length < smEpsilon:
-        revAxisV = p2 - p1
         break
       if (p2 - p0).Length < smEpsilon:
-        revAxisV = p1 - p2
         break
 
     # find the large face connected with selected face
@@ -211,10 +209,9 @@ def smExtrude(extLength = 10.0, gap1 = 0.0, gap2 = 0.0, subtraction = False, off
     # Main Length Edge, Extrusion direction
 #    MlenEdge = lenEdge
 #    leng = MlenEdge.Length
-    revAxisV.normalize()
-    # Get normal of Cface at p1 to correctly handle cylindrical connecting faces
-    params = Cface.Surface.projectPoint(p1, "LowerDistanceParameters")
-    thkDir = Cface.normalAt(params[0], params[1]) * -1
+    pThkDir1 = selFace.CenterOfGravity
+    pThkDir2 = lenEdge.Curve.projectPoint(pThkDir1, "NearestPoint")
+    thkDir = pThkDir1.sub(pThkDir2).normalize()
     FaceDir = selFace.normalAt(0,0)
 
     # if sketch is as wall
@@ -611,4 +608,3 @@ class SMExtrudeCommandClass():
     return True
 
 Gui.addCommand('SMExtrudeFace',SMExtrudeCommandClass())
-


### PR DESCRIPTION
An improved version of https://github.com/shaise/FreeCAD_SheetMetal/pull/237 for `smExtrude`. The thkDir is now derived from the planar selFace. This leads to a better result if the connecting faces have an angle with the selFace that is not 90 degrees (although such an angle is probably technically incorrect).

The same solution was also applied to `getBendetail`. This solves the "Make Wall" bug for cylindrical connecting faces that was reported on the Forum: https://forum.freecadweb.org/viewtopic.php?p=612859#p612859

Additionally:
The revAxisV vector is not used in `smExtrude` and was therefore removed.
