### PR TITLE
Add the option to auto-link wall bend radius

### DIFF
--- a/SMprefs.ui
+++ b/SMprefs.ui
@@ -63,10 +63,66 @@
            <number>0</number>
           </property>
           <property name="prefEntry" stdset="0">
-           <string>EngineeringUXMode</string>
+           <cstring>EngineeringUXMode</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <string>Mod/SheetMetal</string>
+           <cstring>Mod/SheetMetal</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Disabled</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Enabled</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Auto Link Bend Radius</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::comboBox_2">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Method of icon grouping</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AutoLinkBendRadius</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/SheetMetal</cstring>
           </property>
           <item>
            <property name="text">

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1360,6 +1360,26 @@ class AddWallCommandClass():
             '1. Select edges or thickness side faces to create bends with walls.\n'
             '2. Use Property editor to modify other parameters')}
 
+  @staticmethod
+  def getOriginalBendObject(obj):
+    from SheetMetalBaseCmd import SMBaseBend
+    for item in obj.OutListRecursive:
+      if (
+        hasattr(item, "Proxy") and
+        (
+          isinstance(item.Proxy, SMBaseBend) or
+          isinstance(item.Proxy, SMBendWall)
+        )
+      ):
+        if not AddWallCommandClass.getOriginalBendObject(item):
+          return item
+    return None
+
+  @staticmethod
+  def autolink_enabled():
+      FSParam = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/SheetMetal")
+      return FSParam.GetInt("AutoLinkBendRadius", 0)
+
   def Activated(self):
     doc = FreeCAD.ActiveDocument
     view = Gui.ActiveDocument.ActiveView
@@ -1383,6 +1403,10 @@ class AddWallCommandClass():
       activeBody.addObject(a)
     SheetMetalBaseCmd.SetViewConfig(a, viewConf)
     FreeCADGui.Selection.clearSelection()
+    if AddWallCommandClass.autolink_enabled():
+      root = AddWallCommandClass.getOriginalBendObject(a)
+      if root:
+        a.setExpression("radius", root.Label + ".radius")
     doc.recompute()
     doc.commitTransaction()
     return


### PR DESCRIPTION
Adds a new preferences entry to automatically link the bend radius of newly created sheet metal walls to their earliest dependent Bend or BaseBend object.

Closes #257

![image](https://user-images.githubusercontent.com/37948669/214198861-8a3ef7df-42c4-49e7-9828-5d3a2a6cd449.png)

![image](https://user-images.githubusercontent.com/37948669/214199029-2c3f83d1-c38e-4a90-968b-8f18f9c174bb.png)


This is a first attempt, I would appreciate comments on the implementation and design of this feature, as well as testing to see if it breaks in any edge cases.