### PR TITLE
SheetMetalUnfolder Comment out debugging library...

### DIFF
--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -108,9 +108,9 @@ from FreeCAD import Base
 import DraftVecUtils, math, time
 import Draft
 
-import traceback
+# import traceback
 
-traceback.print_exc()
+# traceback.print_exc()
 
 try:
     from TechDraw import projectEx


### PR DESCRIPTION
... as all it's doing is creating a _NoneType: None_ error for users on activation of workbench.
```
OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.35596 (Git)
Build type: Release
Branch: main
Hash: 27a0fb1e9953c0493388319aaff510cf1d9afb66
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * Assembly4 0.50.6
  * freecad.gears 1.2.0
  * Curves 0.6.22
  * CfdOF 1.25.1
  * fasteners 0.5.0
  * sheetmetal 0.3.15
```
