### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>0.4.00</version>
   <date>2024-01-27</date>
   <maintainer email="shaise@gmail.com">Shai Seger</maintainer>
-  <license file="LICENSE">LGPLv2.1</license>
+  <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="master">https://github.com/shaise/FreeCAD_SheetMetal</url>
   <url type="readme">https://github.com/shaise/FreeCAD_SheetMetal/blob/master/README.md</url>
   <icon>Resources/icons/SMLogo.svg</icon>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.1-only`, in which case use that instead.
