### PR TITLE
Rename commands to coincide with Wiki pages

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -43,7 +43,6 @@ main_smWB_Icon = os.path.join(smWB_icons_path, "SMLogo.svg")
 
 
 class SMWorkbench(Workbench):
-
     global main_smWB_Icon
     global SHEETMETALWB_VERSION
     global QtCore
@@ -76,21 +75,23 @@ class SMWorkbench(Workbench):
         import os.path
 
         self.list = [
-            "SMBase",
-            "SMMakeWall",
-            "SMExtrudeFace",
-            "SMFoldWall",
-            "SMUnfold",
-            "SMCornerRelief",
-            "SMMakeRelief",
-            "SMMakeJunction",
-            "SMMakeBend",
-            "SMSketchOnSheet",
-            "SMFormingWall",
-            "SMBaseShape"
+            "SheetMetal_AddBase",
+            "SheetMetal_AddWall",
+            "SheetMetal_Extrude",
+            "SheetMetal_AddFoldWall",
+            "SheetMetal_Unfold",
+            "SheetMetal_AddCornerRelief",
+            "SheetMetal_AddRelief",
+            "SheetMetal_AddJunction",
+            "SheetMetal_AddBend",
+            "SheetMetal_SketchOnSheet",
+            "SheetMetal_Forming",
+            "SheetMetal_BaseShape",
         ]  # A list of command names created in the line above
         if engineering_mode_enabled():
-            self.list.insert(self.list.index("SMUnfold") + 1, "SMUnfoldUnattended")
+            self.list.insert(
+                self.list.index("SheetMetal_Unfold") + 1, "SheetMetal_UnattendedUnfold"
+            )
         self.appendToolbar(
             FreeCAD.Qt.translate("SheetMetal", "Sheet Metal"), self.list
         )  # creates a new toolbar with your commands

--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -64,7 +64,12 @@ def smIsOperationLegal(body, selobj):
     # FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsSketchObject(selobj) and not smBelongToBody(selobj, body):
         smWarnDialog(
-            "The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it."
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it.",
+            )
         )
         return False
     return True

--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -363,4 +363,4 @@ class AddBaseCommandClass:
         return True
 
 
-Gui.addCommand("SMBase", AddBaseCommandClass())
+Gui.addCommand("SheetMetal_AddBase", AddBaseCommandClass())

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -374,4 +374,4 @@ class SMBaseshapeCommandClass:
     def IsActive(self):
         return FreeCAD.ActiveDocument is not None
 
-Gui.addCommand("SMBaseShape", SMBaseshapeCommandClass())
+Gui.addCommand("SheetMetal_BaseShape", SMBaseshapeCommandClass())

--- a/SheetMetalBend.py
+++ b/SheetMetalBend.py
@@ -69,7 +69,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalBend.py
+++ b/SheetMetalBend.py
@@ -451,5 +451,5 @@ class AddBendCommandClass():
         return False
     return True
 
-Gui.addCommand('SMMakeBend',AddBendCommandClass())
+Gui.addCommand("SheetMetal_AddBend", AddBendCommandClass())
 

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -119,7 +119,12 @@ def smIsOperationLegal(body, selobj):
     # FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
         smWarnDialog(
-            "The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it."
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it.",
+            )
         )
         return False
     return True

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1906,4 +1906,4 @@ class AddWallCommandClass:
         return True
 
 
-Gui.addCommand("SMMakeWall", AddWallCommandClass())
+Gui.addCommand("SheetMetal_AddWall", AddWallCommandClass())

--- a/SheetMetalCornerReliefCmd.py
+++ b/SheetMetalCornerReliefCmd.py
@@ -624,5 +624,5 @@ class AddCornerReliefCommandClass():
         return False
     return True
 
-Gui.addCommand('SMCornerRelief',AddCornerReliefCommandClass())
+Gui.addCommand("SheetMetal_AddCornerRelief", AddCornerReliefCommandClass())
 

--- a/SheetMetalCornerReliefCmd.py
+++ b/SheetMetalCornerReliefCmd.py
@@ -70,7 +70,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -71,7 +71,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -640,4 +640,4 @@ class SMExtrudeCommandClass():
         return False
     return True
 
-Gui.addCommand('SMExtrudeFace',SMExtrudeCommandClass())
+Gui.addCommand("SheetMetal_Extrude", SMExtrudeCommandClass())

--- a/SheetMetalFoldCmd.py
+++ b/SheetMetalFoldCmd.py
@@ -441,4 +441,4 @@ class AddFoldWallCommandClass():
       return False
     return True
 
-Gui.addCommand('SMFoldWall',AddFoldWallCommandClass())
+Gui.addCommand("SheetMetal_AddFoldWall", AddFoldWallCommandClass())

--- a/SheetMetalFoldCmd.py
+++ b/SheetMetalFoldCmd.py
@@ -68,7 +68,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -68,7 +68,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -527,5 +527,5 @@ class AddFormingWallCommand():
         return False
     return True
 
-Gui.addCommand('SMFormingWall', AddFormingWallCommand())
+Gui.addCommand("SheetMetal_Forming", AddFormingWallCommand())
 

--- a/SheetMetalJunction.py
+++ b/SheetMetalJunction.py
@@ -69,7 +69,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalJunction.py
+++ b/SheetMetalJunction.py
@@ -406,5 +406,5 @@ class AddJunctionCommandClass():
         return False
     return True
 
-Gui.addCommand('SMMakeJunction',AddJunctionCommandClass())
+Gui.addCommand("SheetMetal_AddJunction", AddJunctionCommandClass())
 

--- a/SheetMetalRelief.py
+++ b/SheetMetalRelief.py
@@ -454,5 +454,5 @@ class AddReliefCommandClass():
         return False
     return True
 
-Gui.addCommand('SMMakeRelief',AddReliefCommandClass())
+Gui.addCommand("SheetMetal_AddRelief", AddReliefCommandClass())
 

--- a/SheetMetalRelief.py
+++ b/SheetMetalRelief.py
@@ -70,7 +70,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -93,7 +93,7 @@ class SMUnfoldUnattendedCommandClass:
         return isinstance(selFace.Surface, Part.Plane)
 
 
-Gui.addCommand("SMUnfoldUnattended", SMUnfoldUnattendedCommandClass())
+Gui.addCommand("SheetMetal_UnattendedUnfold", SMUnfoldUnattendedCommandClass())
 
 
 class SMUnfoldCommandClass:
@@ -142,5 +142,4 @@ class SMUnfoldCommandClass:
         selFace = Gui.Selection.getSelectionEx()[0].SubObjects[0]
         return isinstance(selFace.Surface, Part.Plane)
 
-
-Gui.addCommand("SMUnfold", SMUnfoldCommandClass())
+Gui.addCommand("SheetMetal_Unfold", SMUnfoldCommandClass())

--- a/SketchOnSheetMetalCmd.py
+++ b/SketchOnSheetMetalCmd.py
@@ -69,7 +69,7 @@ def smIsOperationLegal(body, selobj):
                 "QMessageBox",
                 "The selected geometry does not belong to the active Body.\n"
                 "Please make the container of this item active by\n"
-                "double clicking on it."
+                "double clicking on it.",
             )
         )
         return False

--- a/SketchOnSheetMetalCmd.py
+++ b/SketchOnSheetMetalCmd.py
@@ -462,4 +462,4 @@ class AddSketchOnSheetCommandClass():
 #      return False
     return True
 
-Gui.addCommand('SMSketchOnSheet',AddSketchOnSheetCommandClass())
+Gui.addCommand("SheetMetal_SketchOnSheet", AddSketchOnSheetCommandClass())

--- a/UnfoldGUI.py
+++ b/UnfoldGUI.py
@@ -134,7 +134,9 @@ class SMUnfoldTaskPanel:
                 "<li>Or use a <a href='{}'>Material Definition Sheet</a></li>\n"
                 "</ol>",
             ).format(mds_help_url)
-            QtGui.QMessageBox.warning(None, "Warning", msg)
+            QtGui.QMessageBox.warning(
+                None, FreeCAD.Qt.translate("QMessageBox", "Warning"), msg
+            )
             return None
         else:
             lookupTable = SheetMetalKfactor.KFactorLookupTable(

--- a/translations/SheetMetal.ts
+++ b/translations/SheetMetal.ts
@@ -438,6 +438,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="68"/>
+        <location filename="../SheetMetalRelief.py" line="69"/>
+        <location filename="../SheetMetalJunction.py" line="68"/>
+        <location filename="../SheetMetalFormingCmd.py" line="67"/>
+        <location filename="../SheetMetalFoldCmd.py" line="67"/>
+        <location filename="../SheetMetalExtendCmd.py" line="70"/>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="69"/>
+        <location filename="../SheetMetalCmd.py" line="122"/>
+        <location filename="../SheetMetalBend.py" line="68"/>
+        <location filename="../SheetMetalBaseCmd.py" line="67"/>
+        <source>The selected geometry does not belong to the active Body.
+Please make the container of this item active by
+double clicking on it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../UnfoldGUI.py" line="130"/>
         <source>&lt;ol&gt;
 &lt;li&gt;Either select &apos;Manual K-factor&apos;&lt;/li&gt;
@@ -446,16 +462,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../UnfoldGUI.py" line="250"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../UnfoldGUI.py" line="240"/>
         <source>Unfold is failing.
 Please try to select a different face to unfold your object
 
 If the opposite face also fails then switch Refine to false on feature </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UnfoldGUI.py" line="250"/>
-        <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Same as in Fasteners WB, to be able to use the `What's this?` command we need to synchronize the names.

You need to choose what names you prefer to be used.

| WB name | Wiki name |    |
|---------|-----------|----|
|Base| AddBase|  |
| MakeWall | AddWall |  |
| ExtrudeFace | Extrude |  |
| FoldWall | AddFoldWall |  |
| Unfold | Unfold | OK |
| UnfoldUnattended | UnattendedUnfold |  |
| CornerRelief | AddCornerRelief |  |
| MakeRelief | AddRelief |  | 
| MakeJunction | AddJunction |  |
| MakeBend | AddBend |  |
| SketchOnSheet | SketchOnSheet | OK | 
| FormingWall | Forming | |
| BaseShape | BaseShape | OK |