### PR TITLE
Fix translation bug on enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # FreeCAD SheetMetal Workbench
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/shaise/FreeCAD_SheetMetal.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/shaise/FreeCAD_SheetMetal/alerts/) [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/shaise/FreeCAD_SheetMetal.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/shaise/FreeCAD_SheetMetal/context:python)  
 
 A simple sheet metal tools workbench for FreeCAD
 

--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -39,7 +39,9 @@ Gui.updateLocale()
 
 def smWarnDialog(msg):
     diag = QtGui.QMessageBox(
-        QtGui.QMessageBox.Warning, "Error in macro MessageBox", msg
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
     )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
@@ -73,7 +75,7 @@ def GetViewConfig(obj):
     viewconf["objShapeCol"] = obj.ViewObject.ShapeColor
     viewconf["objShapeTsp"] = obj.ViewObject.Transparency
     viewconf["objDiffuseCol"] = obj.ViewObject.DiffuseColor
-    # TODO Make the individual face colors be retained
+    # TODO: Make the individual face colors be retained
     # needDiffuseColorExtension = ( len(selobj.ViewObject.DiffuseColor) < len(selobj.Shape.Faces) )
     return viewconf
 

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -239,8 +239,10 @@ class SMBaseShapeViewProviderFlat:
         return os.path.join( iconPath , 'SheetMetal_AddBaseShape.svg')
 
     def setEdit(self, vobj, mode):
-        SMLogger.log("Base shape edit mode: " + str(mode))
-        if (mode != 0):
+        SMLogger.log(
+            FreeCAD.Qt.translate("Logger", "Base shape edit mode: ") + str(mode)
+        )
+        if mode != 0:
             return None
             return super.setEdit(vobj, mode)
         taskd = BaseShapeTaskPanel()

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -38,6 +38,7 @@ mw = FreeCADGui.getMainWindow()
 # changes in modeling logic
 smElementMapVersion = 'sm1.'
 
+base_shape_types = ["L-Shape", "U-Shape", "Tub", "Hat", "Box"]
 
 ##########################################################################################################
 # Task
@@ -95,7 +96,10 @@ class BaseShapeTaskPanel:
         self.obj.height = self.form.bHeightSpin.property('value')
         self.obj.flangeWidth = self.form.bFlangeWidthSpin.property('value')
         self.obj.length = self.form.bLengthSpin.property('value')
-        self.obj.shapeType = self.form.shapeType.currentText()
+        selected_type = self.form.shapeType.currentText()
+        if selected_type not in base_shape_types:
+            selected_type = base_shape_types[self.form.shapeType.currentIndex()]
+        self.obj.shapeType = selected_type
         self.obj.fillGaps = self._stateToBool(self.form.chkFillGaps.checkState())
 
     def accept(self):
@@ -144,14 +148,14 @@ def smCreateBaseShape(type, thickness, radius, width, length, height, flangeWidt
     if type == "U-Shape":
         numfolds = 2
         width -= 2.0 * bendCompensation
-    elif type == "Tub" or type == "Hat" or type == "Box":
+    elif type in ["Tub", "Hat", "Box"]:
         numfolds = 4
         width -= 2.0 * bendCompensation
         length -= 2.0 * bendCompensation
     else:
         numfolds = 1
         width -= bendCompensation
-    if type == "Hat" or type == "Box":
+    if type in ["Hat", "Box"]:
         height -= bendCompensation
         flangeWidth -= radius
     if width < thickness: width = thickness
@@ -170,7 +174,7 @@ def smCreateBaseShape(type, thickness, radius, width, length, height, flangeWidt
 
     shape, f = smBend(thickness, selFaceNames = faces, extLen = height, bendR = radius,
                       MainObject = box, automiter = fillGaps)
-    if type == "Hat" or type == "Box":
+    if type in ["Hat", "Box"]:
         faces = []
         invertBend = False
         if type == "Hat": invertBend = True
@@ -269,7 +273,7 @@ class SMBaseShape:
         smAddLengthProperty(obj, "length", "Shape length", 30.0)
         smAddLengthProperty(obj, "height", "Shape height", 10.0)
         smAddLengthProperty(obj, "flangeWidth", "Width of top flange", 5.0)
-        smAddEnumProperty(obj, "shapeType", "Base shape type", ["L-Shape", "U-Shape", "Tub", "Hat", "Box"])
+        smAddEnumProperty(obj, "shapeType", "Base shape type", base_shape_types)
         smAddBoolProperty(obj, "fillGaps", "Extend sides and flange to close all gaps", True)
 
     def getElementMapVersion(self, _fp, ver, _prop, restored):

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -267,14 +267,56 @@ class SMBaseShape:
         obj.Proxy = self
 
     def _addVerifyProperties(self, obj):
-        smAddLengthProperty(obj, "thickness", "Thickness of sheetmetal", 1.0)
-        smAddLengthProperty(obj, "radius", "Bend Radius", 1.0)
-        smAddLengthProperty(obj, "width", "Shape width", 20.0)
-        smAddLengthProperty(obj, "length", "Shape length", 30.0)
-        smAddLengthProperty(obj, "height", "Shape height", 10.0)
-        smAddLengthProperty(obj, "flangeWidth", "Width of top flange", 5.0)
-        smAddEnumProperty(obj, "shapeType", "Base shape type", base_shape_types)
-        smAddBoolProperty(obj, "fillGaps", "Extend sides and flange to close all gaps", True)
+        smAddLengthProperty(
+            obj,
+            "thickness",
+            FreeCAD.Qt.translate("SMBaseShape", "Thickness of sheetmetal", "Property"),
+            1.0,
+        )
+        smAddLengthProperty(
+            obj,
+            "radius",
+            FreeCAD.Qt.translate("SMBaseShape", "Bend Radius", "Property"),
+            1.0,
+        )
+        smAddLengthProperty(
+            obj,
+            "width",
+            FreeCAD.Qt.translate("SMBaseShape", "Shape width", "Property"),
+            20.0,
+        )
+        smAddLengthProperty(
+            obj,
+            "length",
+            FreeCAD.Qt.translate("SMBaseShape", "Shape length", "Property"),
+            30.0,
+        )
+        smAddLengthProperty(
+            obj,
+            "height",
+            FreeCAD.Qt.translate("SMBaseShape", "Shape height", "Property"),
+            10.0,
+        )
+        smAddLengthProperty(
+            obj,
+            "flangeWidth",
+            FreeCAD.Qt.translate("SMBaseShape", "Width of top flange", "Property"),
+            5.0,
+        )
+        smAddEnumProperty(
+            obj,
+            "shapeType",
+            FreeCAD.Qt.translate("SMBaseShape", "Base shape type", "Property"),
+            base_shape_types,
+        )
+        smAddBoolProperty(
+            obj,
+            "fillGaps",
+            FreeCAD.Qt.translate(
+                "SMBaseShape", "Extend sides and flange to close all gaps", "Property"
+            ),
+            True,
+        )
 
     def getElementMapVersion(self, _fp, ver, _prop, restored):
         if not restored:

--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -54,7 +54,7 @@ class BaseShapeTaskPanel:
 
     def _boolToState(self, bool):
         return QtCore.Qt.Checked if bool else QtCore.Qt.Unchecked
-    
+
     def _stateToBool(self, state):
         return True if state == QtCore.Qt.Checked else False
 
@@ -71,7 +71,7 @@ class BaseShapeTaskPanel:
         self.form.shapeType.currentIndexChanged.connect(self.typeChanged)
         self.form.chkFillGaps.stateChanged.connect(self.checkChanged)
         self.form.update()
-        
+
         #SMLogger.log(str(self.formReady) + " <2 \n")
 
     def spinValChanged(self):
@@ -79,7 +79,7 @@ class BaseShapeTaskPanel:
            return
         self.updateObj()
         self.obj.recompute()
-        
+
     def typeChanged(self):
         self.spinValChanged()
 
@@ -140,7 +140,7 @@ class BaseShapeTaskPanel:
 
 def smCreateBaseShape(type, thickness, radius, width, length, height, flangeWidth, fillGaps):
     bendCompensation = thickness + radius
-    height -= bendCompensation    
+    height -= bendCompensation
     if type == "U-Shape":
         numfolds = 2
         width -= 2.0 * bendCompensation
@@ -167,8 +167,8 @@ def smCreateBaseShape(type, thickness, radius, width, length, height, flangeWidt
             (v.x > 0.5 and numfolds > 2) or
             (v.x < -0.5 and numfolds > 3)):
             faces.append("Face" + str(i+1))
-    
-    shape, f = smBend(thickness, selFaceNames = faces, extLen = height, bendR = radius, 
+
+    shape, f = smBend(thickness, selFaceNames = faces, extLen = height, bendR = radius,
                       MainObject = box, automiter = fillGaps)
     if type == "Hat" or type == "Box":
         faces = []
@@ -179,10 +179,10 @@ def smCreateBaseShape(type, thickness, radius, width, length, height, flangeWidt
             z = shape.Faces[i].CenterOfGravity.z
             if v.z > 0.9999 and z > bendCompensation:
                 faces.append("Face" + str(i+1))
-        shape, f = smBend(thickness, selFaceNames = faces, extLen = flangeWidth, 
+        shape, f = smBend(thickness, selFaceNames = faces, extLen = flangeWidth,
                           bendR = radius, MainObject = shape, flipped = invertBend,
                           automiter = fillGaps)
-            
+
 
 
 
@@ -278,9 +278,9 @@ class SMBaseShape:
 
     def execute(self, fp):
         self._addVerifyProperties(fp)
-        s = smCreateBaseShape(type = fp.shapeType, thickness = fp.thickness.Value, 
-                              radius = fp.radius.Value, width = fp.width.Value, 
-                              length = fp.length.Value, height = fp.height.Value, 
+        s = smCreateBaseShape(type = fp.shapeType, thickness = fp.thickness.Value,
+                              radius = fp.radius.Value, width = fp.width.Value,
+                              length = fp.length.Value, height = fp.height.Value,
                               flangeWidth = fp.flangeWidth.Value, fillGaps = fp.fillGaps)
 
         fp.Shape = s

--- a/SheetMetalBend.py
+++ b/SheetMetalBend.py
@@ -42,7 +42,11 @@ Gui.updateLocale()
 smElementMapVersion = 'sm1.'
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -60,7 +64,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -94,7 +94,9 @@ def smAddEnumProperty(
 
 def smWarnDialog(msg):
     diag = QtGui.QMessageBox(
-        QtGui.QMessageBox.Warning, "Error in macro MessageBox", msg
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg
     )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -42,29 +42,48 @@ Gui.updateLocale()
 # changes in modeling logic
 smElementMapVersion = "sm1."
 
-def smAddProperty(obj, proptype, name, proptip, defval = None, paramgroup = "Parameters"):
+
+def smAddProperty(obj, proptype, name, proptip, defval=None, paramgroup="Parameters"):
+    """
+    Add a property to a given object.
+
+    Args:
+    - obj: The object to which the property should be added.
+    - proptype: The type of the property (e.g., "App::PropertyLength", "App::PropertyBool").
+    - name: The name of the property. Non-translatable.
+    - proptip: The tooltip for the property. Need to be translated from outside.
+    - defval: The default value for the property (optional).
+    - paramgroup: The parameter group to which the property should belong (default is "Parameters").
+    """
     if not hasattr(obj, name):
-        _tip_ = FreeCAD.Qt.translate("App::Property",proptip)
-        obj.addProperty(proptype, name, paramgroup, _tip_)
+        obj.addProperty(proptype, name, paramgroup, proptip)
         if defval is not None:
             setattr(obj, name, defval)
 
-def smAddLengthProperty(obj, name, proptip, defval, paramgroup = "Parameters"):
+
+def smAddLengthProperty(obj, name, proptip, defval, paramgroup="Parameters"):
     smAddProperty(obj, "App::PropertyLength", name, proptip, defval, paramgroup)
 
-def smAddBoolProperty(obj, name, proptip, defval, paramgroup = "Parameters"):
+
+def smAddBoolProperty(obj, name, proptip, defval, paramgroup="Parameters"):
     smAddProperty(obj, "App::PropertyBool", name, proptip, defval, paramgroup)
 
-def smAddDistanceProperty(obj, name, proptip, defval, paramgroup = "Parameters"):
+
+def smAddDistanceProperty(obj, name, proptip, defval, paramgroup="Parameters"):
     smAddProperty(obj, "App::PropertyDistance", name, proptip, defval, paramgroup)
 
-def smAddAngleProperty(obj, name, proptip, defval, paramgroup = "Parameters"):
+
+def smAddAngleProperty(obj, name, proptip, defval, paramgroup="Parameters"):
     smAddProperty(obj, "App::PropertyAngle", name, proptip, defval, paramgroup)
 
-def smAddFloatProperty(obj, name, proptip, defval, paramgroup = "Parameters"):
+
+def smAddFloatProperty(obj, name, proptip, defval, paramgroup="Parameters"):
     smAddProperty(obj, "App::PropertyFloat", name, proptip, defval, paramgroup)
 
-def smAddEnumProperty(obj, name, proptip, enumlist, defval = None, paramgroup = "Parameters"):
+
+def smAddEnumProperty(
+    obj, name, proptip, enumlist, defval=None, paramgroup="Parameters"
+):
     if not hasattr(obj, name):
         _tip_ = FreeCAD.Qt.translate("App::Property", proptip)
         obj.addProperty("App::PropertyEnumeration", name, paramgroup, _tip_)
@@ -478,7 +497,7 @@ def getBendetail(selItemNames, MainObject, bendR, bendA, isflipped, offset, gap1
 
         if type(MainObject.getElement(selItemName)) == Part.Edge:
             flipped = not flipped
-       
+
         if not (flipped):
             revAxisP = lenEdge.valueAt(lenEdge.FirstParameter) + thkDir * (bendR + thk)
             revAxisV = revAxisV * -1
@@ -555,7 +574,6 @@ def smMiter(
     mingap=0.1,
     maxExtendGap=5.0,
 ):
-
     if not (automiter):
         miterA1List = [miterA1 for n in mainlist]
         miterA2List = [miterA2 for n in mainlist]
@@ -861,7 +879,6 @@ def smBend(
     extendType="Simple",
     LengthSpec="Leg",
 ):
-
     # if sketch is as wall
     sketches = False
     if sketch:
@@ -1281,40 +1298,198 @@ class SMBendWall:
         obj.Proxy = self
 
     def _addProperties(self, obj):
-
-        smAddLengthProperty(obj, "radius", "Bend Radius", 1.0)
-        smAddLengthProperty(obj, "length", "Length of Wall", 10.0)
-        smAddDistanceProperty(obj, "gap1", "Gap from Left Side", 0.0)
-        smAddDistanceProperty(obj, "gap2", "Gap from Right Side", 0.0)
-        smAddBoolProperty(obj, "invert", "Invert Bend Direction", False)
-        smAddAngleProperty(obj, "angle", "Bend Angle", 90.0)
-        smAddDistanceProperty(obj, "extend1", "Extend from Left Side", 0.0)
-        smAddDistanceProperty(obj, "extend2", "Extend from Right Side", 0.0)
-        smAddEnumProperty(obj, "BendType", "Bend Type", 
-                          ["Material Outside", "Material Inside", "Thickness Outside", "Offset"])
-        smAddEnumProperty(obj, "LengthSpec", "Type of Length Specification", 
-                          ["Leg", "Outer Sharp", "Inner Sharp", "Tangential"])
-        smAddLengthProperty(obj, "reliefw", "Relief Width", 0.8, "ParametersRelief")
-        smAddLengthProperty(obj, "reliefd", "Relief Depth", 1.0, "ParametersRelief")
-        smAddBoolProperty(obj, "UseReliefFactor", "Use Relief Factor", False, "ParametersRelief")
-        smAddEnumProperty(obj, "reliefType", "Relief Type", ["Rectangle", "Round"], None, "ParametersRelief")
-        smAddFloatProperty(obj, "ReliefFactor", "Relief Factor", 0.7, "ParametersRelief")
-        smAddAngleProperty(obj, "miterangle1", "Bend Miter Angle from Left Side", 0.0, "ParametersMiterangle")
-        smAddAngleProperty(obj, "miterangle2", "Bend Miter Angle from Right Side", 0.0, "ParametersMiterangle")
-        smAddLengthProperty(obj, "minGap", "Auto Miter Minimum Gap", 0.2, "ParametersEx")
-        smAddLengthProperty(obj, "maxExtendDist", "Auto Miter maximum Extend Distance", 5.0, "ParametersEx")
-        smAddLengthProperty(obj, "minReliefGap", "Minimum Gap to Relief Cut", 1.0, "ParametersEx")
-        smAddDistanceProperty(obj, "offset", "Offset Bend", 0.0, "ParametersEx")
-        smAddBoolProperty(obj, "AutoMiter", "Enable Auto Miter", True, "ParametersEx")
-        smAddBoolProperty(obj, "unfold", "Shows Unfold View of Current Bend", False, "ParametersEx")
-        smAddProperty(obj, "App::PropertyFloatConstraint", "kfactor", 
-                      "Location of Neutral Line. Caution: Using ANSI standards, not DIN.", 
-                      (0.5, 0.0, 1.0, 0.01), "ParametersEx")
-        smAddBoolProperty(obj, "sketchflip", "Flip Sketch Direction", False, "ParametersEx2")
-        smAddBoolProperty(obj, "sketchinvert", "Invert Sketch Start", False, "ParametersEx2")
-        smAddProperty(obj, "App::PropertyLink", "Sketch", "Sketch Object", None, "ParametersEx2")
-        smAddProperty(obj, "App::PropertyFloatList", "LengthList", "Length of Wall List", None, "ParametersEx3")
-        smAddProperty(obj, "App::PropertyFloatList", "bendAList", "Bend Angle List", None, "ParametersEx3")
+        smAddLengthProperty(
+            obj, "radius", FreeCAD.Qt.translate("App::Property", "Bend Radius"), 1.0
+        )
+        smAddLengthProperty(
+            obj, "length", FreeCAD.Qt.translate("App::Property", "Length of Wall"), 10.0
+        )
+        smAddDistanceProperty(
+            obj,
+            "gap1",
+            FreeCAD.Qt.translate("App::Property", "Gap from Left Side"),
+            0.0,
+        )
+        smAddDistanceProperty(
+            obj,
+            "gap2",
+            FreeCAD.Qt.translate("App::Property", "Gap from Right Side"),
+            0.0,
+        )
+        smAddBoolProperty(
+            obj,
+            "invert",
+            FreeCAD.Qt.translate("App::Property", "Invert Bend Direction"),
+            False,
+        )
+        smAddAngleProperty(
+            obj, "angle", FreeCAD.Qt.translate("App::Property", "Bend Angle"), 90.0
+        )
+        smAddDistanceProperty(
+            obj,
+            "extend1",
+            FreeCAD.Qt.translate("App::Property", "Extend from Left Side"),
+            0.0,
+        )
+        smAddDistanceProperty(
+            obj,
+            "extend2",
+            FreeCAD.Qt.translate("App::Property", "Extend from Right Side"),
+            0.0,
+        )
+        smAddEnumProperty(
+            obj,
+            "BendType",
+            FreeCAD.Qt.translate("App::Property", "Bend Type"),
+            ["Material Outside", "Material Inside", "Thickness Outside", "Offset"],
+        )
+        smAddEnumProperty(
+            obj,
+            "LengthSpec",
+            FreeCAD.Qt.translate("App::Property", "Type of Length Specification"),
+            ["Leg", "Outer Sharp", "Inner Sharp", "Tangential"],
+        )
+        smAddLengthProperty(
+            obj,
+            "reliefw",
+            FreeCAD.Qt.translate("App::Property", "Relief Width"),
+            0.8,
+            "ParametersRelief",
+        )
+        smAddLengthProperty(
+            obj,
+            "reliefd",
+            FreeCAD.Qt.translate("App::Property", "Relief Depth"),
+            1.0,
+            "ParametersRelief",
+        )
+        smAddBoolProperty(
+            obj,
+            "UseReliefFactor",
+            FreeCAD.Qt.translate("App::Property", "Use Relief Factor"),
+            False,
+            "ParametersRelief",
+        )
+        smAddEnumProperty(
+            obj,
+            "reliefType",
+            FreeCAD.Qt.translate("App::Property", "Relief Type"),
+            ["Rectangle", "Round"],
+            None,
+            "ParametersRelief",
+        )
+        smAddFloatProperty(
+            obj,
+            "ReliefFactor",
+            FreeCAD.Qt.translate("App::Property", "Relief Factor"),
+            0.7,
+            "ParametersRelief",
+        )
+        smAddAngleProperty(
+            obj,
+            "miterangle1",
+            FreeCAD.Qt.translate("App::Property", "Bend Miter Angle from Left Side"),
+            0.0,
+            "ParametersMiterangle",
+        )
+        smAddAngleProperty(
+            obj,
+            "miterangle2",
+            FreeCAD.Qt.translate("App::Property", "Bend Miter Angle from Right Side"),
+            0.0,
+            "ParametersMiterangle",
+        )
+        smAddLengthProperty(
+            obj,
+            "minGap",
+            FreeCAD.Qt.translate("App::Property", "Auto Miter Minimum Gap"),
+            0.2,
+            "ParametersEx",
+        )
+        smAddLengthProperty(
+            obj,
+            "maxExtendDist",
+            FreeCAD.Qt.translate("App::Property", "Auto Miter maximum Extend Distance"),
+            5.0,
+            "ParametersEx",
+        )
+        smAddLengthProperty(
+            obj,
+            "minReliefGap",
+            FreeCAD.Qt.translate("App::Property", "Minimum Gap to Relief Cut"),
+            1.0,
+            "ParametersEx",
+        )
+        smAddDistanceProperty(
+            obj,
+            "offset",
+            FreeCAD.Qt.translate("App::Property", "Offset Bend"),
+            0.0,
+            "ParametersEx",
+        )
+        smAddBoolProperty(
+            obj,
+            "AutoMiter",
+            FreeCAD.Qt.translate("App::Property", "Enable Auto Miter"),
+            True,
+            "ParametersEx",
+        )
+        smAddBoolProperty(
+            obj,
+            "unfold",
+            FreeCAD.Qt.translate("App::Property", "Shows Unfold View of Current Bend"),
+            False,
+            "ParametersEx",
+        )
+        smAddProperty(
+            obj,
+            "App::PropertyFloatConstraint",
+            "kfactor",
+            FreeCAD.Qt.translate(
+                "App::Property",
+                "Location of Neutral Line. Caution: Using ANSI standards, not DIN.",
+            ),
+            (0.5, 0.0, 1.0, 0.01),
+            "ParametersEx",
+        )
+        smAddBoolProperty(
+            obj,
+            "sketchflip",
+            FreeCAD.Qt.translate("App::Property", "Flip Sketch Direction"),
+            False,
+            "ParametersEx2",
+        )
+        smAddBoolProperty(
+            obj,
+            "sketchinvert",
+            FreeCAD.Qt.translate("App::Property", "Invert Sketch Start"),
+            False,
+            "ParametersEx2",
+        )
+        smAddProperty(
+            obj,
+            "App::PropertyLink",
+            "Sketch",
+            FreeCAD.Qt.translate("App::Property", "Sketch Object"),
+            None,
+            "ParametersEx2",
+        )
+        smAddProperty(
+            obj,
+            "App::PropertyFloatList",
+            "LengthList",
+            FreeCAD.Qt.translate("App::Property", "Length of Wall List"),
+            None,
+            "ParametersEx3",
+        )
+        smAddProperty(
+            obj,
+            "App::PropertyFloatList",
+            "bendAList",
+            FreeCAD.Qt.translate("App::Property", "Bend Angle List"),
+            None,
+            "ParametersEx3",
+        )
 
     def getElementMapVersion(self, _fp, ver, _prop, restored):
         if not restored:
@@ -1566,7 +1741,6 @@ class SMBendWallTaskPanel:
     """A TaskPanel for the Sheetmetal"""
 
     def __init__(self):
-
         self.obj = None
         self.form = QtGui.QWidget()
         self.form.setObjectName("SMBendWallTaskPanel")
@@ -1625,7 +1799,6 @@ class SMBendWallTaskPanel:
         self.retranslateUi(self.form)
 
     def updateElement(self):
-
         if not self.obj:
             return
 

--- a/SheetMetalCornerReliefCmd.py
+++ b/SheetMetalCornerReliefCmd.py
@@ -43,7 +43,11 @@ import SheetMetalBaseCmd
 from SheetMetalLogger import SMLogger, UnfoldException, BendException, TreeException
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -61,7 +65,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 
@@ -69,7 +80,12 @@ def smthk(obj, foldface) :
   normal = foldface.normalAt(0,0)
   theVol = obj.Volume
   if theVol < 0.0001:
-      SMLogger.error("Shape is not a real 3D-object or to small for a metal-sheet!")
+      SMLogger.error(
+            FreeCAD.Qt.translate(
+                "Logger",
+                "Shape is not a real 3D-object or to small for a metal-sheet!"
+            )
+        )
   else:
       # Make a first estimate of the thickness
       estimated_thk = theVol/(obj.Area / 2.0)

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -44,7 +44,11 @@ Gui.updateLocale()
 smElementMapVersion = 'sm1.'
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -62,7 +66,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 

--- a/SheetMetalFoldCmd.py
+++ b/SheetMetalFoldCmd.py
@@ -41,7 +41,11 @@ import SheetMetalBaseCmd
 from SheetMetalLogger import SMLogger, UnfoldException, BendException, TreeException
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -59,7 +63,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 
@@ -67,7 +78,12 @@ def smthk(obj, foldface) :
   normal = foldface.normalAt(0,0)
   theVol = obj.Volume
   if theVol < 0.0001:
-      SMLogger.error("Shape is not a real 3D-object or to small for a metal-sheet!")
+      SMLogger.error(
+            FreeCAD.Qt.translate(
+                "Logger",
+                "Shape is not a real 3D-object or to small for a metal-sheet!"
+            )
+        )
   else:
       # Make a first estimate of the thickness
       estimated_thk = theVol/(foldface.Area)

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -41,7 +41,11 @@ Gui.addLanguagePath(LanguagePath)
 Gui.updateLocale()
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -59,7 +63,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
  
@@ -67,7 +78,12 @@ def smthk(obj, foldface) :
   normal = foldface.normalAt(0,0)
   theVol = obj.Volume
   if theVol < 0.0001:
-      SMLogger.error("Shape is not a real 3D-object or to small for a metal-sheet!")
+      SMLogger.error(
+            FreeCAD.Qt.translate(
+                "Logger",
+                "Shape is not a real 3D-object or to small for a metal-sheet!"
+            )
+        )
   else:
       # Make a first estimate of the thickness
       estimated_thk = theVol/(obj.Area / 2.0)

--- a/SheetMetalJunction.py
+++ b/SheetMetalJunction.py
@@ -42,7 +42,11 @@ Gui.updateLocale()
 smElementMapVersion = 'sm1.'
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -60,7 +64,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 

--- a/SheetMetalRelief.py
+++ b/SheetMetalRelief.py
@@ -43,7 +43,11 @@ Gui.updateLocale()
 smElementMapVersion = 'sm1.'
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -61,7 +65,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 

--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -59,7 +59,7 @@ class SMUnfoldUnattendedCommandClass:
         }
 
     def Activated(self):
-        SMLogger.message("Running unattended unfold...")
+        SMLogger.message(FreeCAD.Qt.translate("Logger", "Running unattended unfold..."))
         try:
             taskd = SMUnfoldTaskPanel()
         except ValueError as e:
@@ -78,7 +78,7 @@ class SMUnfoldUnattendedCommandClass:
         taskd.form.bendColor.setProperty("color", pg.GetString("bendColor"))
         taskd.form.genColor.setProperty("color", pg.GetString("genColor"))
         taskd.form.internalColor.setProperty("color", pg.GetString("intColor"))
-        #taskd.new_mds_name = taskd.material_sheet_name
+        # taskd.new_mds_name = taskd.material_sheet_name
         taskd.accept()
         return
 
@@ -121,7 +121,6 @@ class SMUnfoldCommandClass:
         }
 
     def Activated(self):
-
         dialog = SMUnfoldTaskPanel()
         FreeCADGui.Control.showDialog(dialog)
 
@@ -142,5 +141,6 @@ class SMUnfoldCommandClass:
             return False
         selFace = Gui.Selection.getSelectionEx()[0].SubObjects[0]
         return isinstance(selFace.Surface, Part.Plane)
+
 
 Gui.addCommand("SMUnfold", SMUnfoldCommandClass())

--- a/SketchOnSheetMetalCmd.py
+++ b/SketchOnSheetMetalCmd.py
@@ -42,7 +42,11 @@ import SheetMetalBendSolid
 from SheetMetalLogger import SMLogger, UnfoldException, BendException, TreeException
 
 def smWarnDialog(msg):
-    diag = QtGui.QMessageBox(QtGui.QMessageBox.Warning, 'Error in macro MessageBox', msg)
+    diag = QtGui.QMessageBox(
+        QtGui.QMessageBox.Warning,
+        FreeCAD.Qt.translate("QMessageBox", "Error in macro MessageBox"),
+        msg,
+    )
     diag.setWindowModality(QtCore.Qt.ApplicationModal)
     diag.exec_()
 
@@ -60,7 +64,14 @@ def smIsPartDesign(obj):
 def smIsOperationLegal(body, selobj):
     #FreeCAD.Console.PrintLog(str(selobj) + " " + str(body) + " " + str(smBelongToBody(selobj, body)) + "\n")
     if smIsPartDesign(selobj) and not smBelongToBody(selobj, body):
-        smWarnDialog("The selected geometry does not belong to the active Body.\nPlease make the container of this item active by\ndouble clicking on it.")
+        smWarnDialog(
+            FreeCAD.Qt.translate(
+                "QMessageBox",
+                "The selected geometry does not belong to the active Body.\n"
+                "Please make the container of this item active by\n"
+                "double clicking on it."
+            )
+        )
         return False
     return True
 
@@ -80,7 +91,12 @@ def smthk(obj, foldface) :
   normal = foldface.normalAt(0,0)
   theVol = obj.Volume
   if theVol < 0.0001:
-      SMLogger.error("Shape is not a real 3D-object or to small for a metal-sheet!")
+      SMLogger.error(
+            FreeCAD.Qt.translate(
+                "Logger",
+                "Shape is not a real 3D-object or to small for a metal-sheet!"
+            )
+        )
   else:
       # Make a first estimate of the thickness
       estimated_thk = theVol/(obj.Area / 2.0)

--- a/UnfoldGUI.py
+++ b/UnfoldGUI.py
@@ -79,7 +79,7 @@ class SMUnfoldTaskPanel:
     def _boolToState(self, bool):
         return QtCore.Qt.Checked if bool else QtCore.Qt.Unchecked
 
-    def _getExportType(self, typeonly = False):
+    def _getExportType(self, typeonly=False):
         if not typeonly and not self.form.chkExport.isChecked():
             return None
         if self.form.svgExport.isChecked():
@@ -88,7 +88,9 @@ class SMUnfoldTaskPanel:
             return "dxf"
 
     def _isManualKSelected(self):
-        return self.form.availableMds.currentIndex() == (self.form.availableMds.count() - 1)
+        return self.form.availableMds.currentIndex() == (
+            self.form.availableMds.count() - 1
+        )
 
     def _isNoMdsSelected(self):
         return self.form.availableMds.currentIndex() == 0
@@ -121,12 +123,17 @@ class SMUnfoldTaskPanel:
         if self._isManualKSelected():
             results["lookupTable"] = {1: self.form.kFactSpin.value()}
         elif self._isNoMdsSelected():
-            msg = "Unfold operation needs to know K-factor value(s) to be used."
+            msg = FreeCAD.Qt.translate(
+                "Logger", "Unfold operation needs to know K-factor value(s) to be used."
+            )
             SMLogger.warning(msg)
-            msg += "<ol>"
-            msg += "<li>Either select 'Manual K-factor'</li>"
-            msg += "<li>Or use a <a href='%s'>Material Definition Sheet</a></li>" % mds_help_url
-            msg += "</ol>"
+            msg += FreeCAD.Qt.translate(
+                "QMessageBox",
+                "<ol>\n"
+                "<li>Either select 'Manual K-factor'</li>\n"
+                "<li>Or use a <a href='{}'>Material Definition Sheet</a></li>\n"
+                "</ol>",
+            ).format(mds_help_url)
             QtGui.QMessageBox.warning(None, "Warning", msg)
             return None
         else:
@@ -181,7 +188,9 @@ class SMUnfoldTaskPanel:
 
         self.form.chkSeparate.setEnabled(self.pg.GetBool("separateSketches", False))
 
-        self.form.chkExport.setCheckState(self._boolToState(self.pg.GetBool("exportEn", False)))
+        self.form.chkExport.setCheckState(
+            self._boolToState(self.pg.GetBool("exportEn", False))
+        )
         if self.pg.GetString("exportType", "dxf") == "dxf":
             self.form.dxfExport.setChecked(True)
         else:
@@ -199,7 +208,6 @@ class SMUnfoldTaskPanel:
         params = self._getData()
         if params is None:
             return
-
 
         try:
             result = smu.processUnfold(
@@ -229,11 +237,20 @@ class SMUnfoldTaskPanel:
 
         except UnfoldException:
             msg = (
-                """Unfold is failing.<br>Please try to select a different face to unfold your object
-                <br><br>If the opposite face also fails then switch Refine to false on feature """
+                FreeCAD.Qt.translate(
+                    "QMessageBox",
+                    "Unfold is failing.\n"
+                    "Please try to select a different face to unfold your object\n\n"
+                    "If the opposite face also fails then switch Refine to false on feature ",
+                )
                 + FreeCADGui.Selection.getSelection()[0].Name
             )
-            QtGui.QMessageBox.question(None, "Warning", msg, QtGui.QMessageBox.Ok)
+            QtGui.QMessageBox.question(
+                None,
+                FreeCAD.Qt.translate("QMessageBox", "Warning"),
+                msg,
+                QtGui.QMessageBox.Ok,
+            )
 
         except Exception as e:
             raise e
@@ -274,13 +291,13 @@ class SMUnfoldTaskPanel:
 
         self.form.availableMds.addItem("Please select")
         for mds in sheetnames:
-            if (mds.Label.startswith("material_")):
+            if mds.Label.startswith("material_"):
                 self.form.availableMds.addItem(mds.Label)
         self.form.availableMds.addItem("Manual K-Factor")
 
         selMdsIndex = self._getLastSelectedMdsIndex()
 
-        if (selMdsIndex >= 0):
+        if selMdsIndex >= 0:
             self.form.availableMds.setCurrentIndex(selMdsIndex)
         elif len(sheetnames) == 1:
             self.form.availableMds.setCurrentIndex(1)
@@ -309,4 +326,3 @@ class SMUnfoldTaskPanel:
         self.form.kfactorAnsi.setEnabled(isManualK)
         self.form.kfactorDin.setEnabled(isManualK)
         self.form.kFactSpin.setEnabled(isManualK)
-

--- a/UnfoldGUI.py
+++ b/UnfoldGUI.py
@@ -86,13 +86,13 @@ class SMUnfoldTaskPanel:
             return "svg"
         else:
             return "dxf"
-        
+
     def _isManualKSelected(self):
         return self.form.availableMds.currentIndex() == (self.form.availableMds.count() - 1)
-    
+
     def _isNoMdsSelected(self):
         return self.form.availableMds.currentIndex() == 0
-    
+
     def _updateSelectedMds(self):
         global last_selected_mds
         last_selected_mds = self.form.availableMds.currentText()
@@ -199,7 +199,7 @@ class SMUnfoldTaskPanel:
         params = self._getData()
         if params is None:
             return
-        
+
 
         try:
             result = smu.processUnfold(
@@ -309,4 +309,4 @@ class SMUnfoldTaskPanel:
         self.form.kfactorAnsi.setEnabled(isManualK)
         self.form.kfactorDin.setEnabled(isManualK)
         self.form.kFactSpin.setEnabled(isManualK)
-        
+

--- a/translations/SheetMetal.ts
+++ b/translations/SheetMetal.ts
@@ -2,6 +2,319 @@
 <!DOCTYPE TS>
 <TS version="2.1">
 <context>
+    <name>App::Property</name>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="242"/>
+        <source>Bend Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBend.py" line="117"/>
+        <source>Thickness of sheetmetal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseCmd.py" line="202"/>
+        <source>Relief Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseCmd.py" line="206"/>
+        <source>Length of wall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseCmd.py" line="210"/>
+        <source>Wall Sketch object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseCmd.py" line="227"/>
+        <source>Extrude Symmetric to Plane</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseCmd.py" line="231"/>
+        <source>Reverse Extrusion Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="310"/>
+        <source>Base object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="288"/>
+        <source>Base Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="304"/>
+        <source>Length of Wall</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="292"/>
+        <source>Gap from Left Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1300"/>
+        <source>Gap from Right Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="254"/>
+        <source>Invert Bend Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="244"/>
+        <source>Bend Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1315"/>
+        <source>Extend from Left Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1321"/>
+        <source>Extend from Right Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1327"/>
+        <source>Bend Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1333"/>
+        <source>Type of Length Specification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1339"/>
+        <source>Relief Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1346"/>
+        <source>Relief Depth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1353"/>
+        <source>Use Relief Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1368"/>
+        <source>Relief Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1375"/>
+        <source>Bend Miter Angle from Left Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1382"/>
+        <source>Bend Miter Angle from Right Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1389"/>
+        <source>Auto Miter Minimum Gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1396"/>
+        <source>Auto Miter maximum Extend Distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1403"/>
+        <source>Minimum Gap to Relief Cut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1410"/>
+        <source>Offset Bend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1417"/>
+        <source>Enable Auto Miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1424"/>
+        <source>Shows Unfold View of Current Bend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1432"/>
+        <source>Location of Neutral Line. Caution: Using ANSI standards, not DIN.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1442"/>
+        <source>Flip Sketch Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1449"/>
+        <source>Invert Sketch Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1457"/>
+        <source>Sketch Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1465"/>
+        <source>Length of Wall List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCmd.py" line="1473"/>
+        <source>Bend Angle List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="434"/>
+        <source>Corner Relief Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="438"/>
+        <source>Size of Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="440"/>
+        <source>Size Ratio of Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="252"/>
+        <source>Neutral Axis Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="444"/>
+        <source>Corner Relief Sketch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="446"/>
+        <source>Gap from side one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="448"/>
+        <source>Gap from side two</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="306"/>
+        <source>Gap from left side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="308"/>
+        <source>Gap from right side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="328"/>
+        <source>Wall Sketch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="338"/>
+        <source>Use Subtraction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="316"/>
+        <source>Offset for subtraction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalExtendCmd.py" line="332"/>
+        <source>Use Refine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="248"/>
+        <source>Bend Reference Line List</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="250"/>
+        <source>Invert Solid Bend Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="256"/>
+        <source>Unfold Bend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFoldCmd.py" line="266"/>
+        <source>Bend Line Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="139"/>
+        <source>Offset from Center of Face</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="141"/>
+        <source>Suppress Forming Feature</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="143"/>
+        <source>Tool Position Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="145"/>
+        <source>Thickness of Sheetmetal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="149"/>
+        <source>Forming Tool Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalFormingCmd.py" line="151"/>
+        <source>Point Sketch on Sheetmetal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalJunction.py" line="104"/>
+        <source>Junction Gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalRelief.py" line="151"/>
+        <source>Relief Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="290"/>
+        <source>Sketch on Sheetmetal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Gui::Dialog::DlgSettingsDraft</name>
     <message>
         <location filename="../SMprefs.ui" line="14"/>
@@ -44,6 +357,164 @@
     <message>
         <location filename="../SMprefs.ui" line="177"/>
         <source>Preferences for the SheetMetal Workbench</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Logger</name>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="243"/>
+        <source>Base shape edit mode: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="88"/>
+        <location filename="../SheetMetalFormingCmd.py" line="75"/>
+        <location filename="../SheetMetalFoldCmd.py" line="75"/>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="77"/>
+        <source>Shape is not a real 3D-object or to small for a metal-sheet!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfoldCmd.py" line="62"/>
+        <source>Running unattended unfold...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="425"/>
+        <source>k_Factor is a readonly property! Won&apos;t set to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="2498"/>
+        <source>at line {} got exception: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="3135"/>
+        <source>exception at line </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="3180"/>
+        <source>Exception at line {}: Outline Sketch failed, re-trying after tidying up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="3197"/>
+        <source>tidying up Unfold_Sketch_Outline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="3219"/>
+        <source>Exception at line {}: Outline Sketch not created</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalUnfolder.py" line="3253"/>
+        <source>discretizing Sketch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UnfoldGUI.py" line="126"/>
+        <source>Unfold operation needs to know K-factor value(s) to be used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QMessageBox</name>
+    <message>
+        <location filename="../SketchOnSheetMetalCmd.py" line="47"/>
+        <location filename="../SheetMetalRelief.py" line="48"/>
+        <location filename="../SheetMetalJunction.py" line="47"/>
+        <location filename="../SheetMetalFormingCmd.py" line="46"/>
+        <location filename="../SheetMetalFoldCmd.py" line="46"/>
+        <location filename="../SheetMetalExtendCmd.py" line="49"/>
+        <location filename="../SheetMetalCornerReliefCmd.py" line="48"/>
+        <location filename="../SheetMetalCmd.py" line="98"/>
+        <location filename="../SheetMetalBend.py" line="47"/>
+        <location filename="../SheetMetalBaseCmd.py" line="43"/>
+        <source>Error in macro MessageBox</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UnfoldGUI.py" line="130"/>
+        <source>&lt;ol&gt;
+&lt;li&gt;Either select &apos;Manual K-factor&apos;&lt;/li&gt;
+&lt;li&gt;Or use a &lt;a href=&apos;{}&apos;&gt;Material Definition Sheet&lt;/a&gt;&lt;/li&gt;
+&lt;/ol&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UnfoldGUI.py" line="240"/>
+        <source>Unfold is failing.
+Please try to select a different face to unfold your object
+
+If the opposite face also fails then switch Refine to false on feature </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../UnfoldGUI.py" line="250"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../SheetMetalRelief.py" line="189"/>
+        <source>Edit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SMBaseShape</name>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="297"/>
+        <source>Thickness of sheetmetal</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="301"/>
+        <source>Bend Radius</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="304"/>
+        <source>Shape width</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="307"/>
+        <source>Shape length</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="310"/>
+        <source>Shape height</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="315"/>
+        <source>Width of top flange</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="321"/>
+        <source>Base shape type</source>
+        <comment>Property</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SheetMetalBaseShapeCmd.py" line="327"/>
+        <source>Extend sides and flange to close all gaps</source>
+        <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -239,213 +710,12 @@
     </message>
 </context>
 <context>
-    <name>App::Property</name>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="242"/>
-        <source>Bend Radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="244"/>
-        <source>Bend Angle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="248"/>
-        <source>Bend Reference Line List</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="250"/>
-        <source>Invert Solid Bend Direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="252"/>
-        <source>Neutral Axis Position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="254"/>
-        <source>Invert Bend Direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="256"/>
-        <source>Unfold Bend</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFoldCmd.py" line="266"/>
-        <source>Bend Line Position</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBend.py" line="117"/>
-        <source>Thickness of sheetmetal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBaseCmd.py" line="202"/>
-        <source>Relief Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBaseCmd.py" line="206"/>
-        <source>Length of wall</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBaseCmd.py" line="210"/>
-        <source>Wall Sketch object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBaseCmd.py" line="227"/>
-        <source>Extrude Symmetric to Plane</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalBaseCmd.py" line="231"/>
-        <source>Reverse Extrusion Direction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="304"/>
-        <source>Length of Wall</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="306"/>
-        <source>Gap from left side</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="308"/>
-        <source>Gap from right side</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="310"/>
-        <source>Base object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="316"/>
-        <source>Offset for subtraction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="328"/>
-        <source>Wall Sketch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="332"/>
-        <source>Use Refine</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalExtendCmd.py" line="338"/>
-        <source>Use Subtraction</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SketchOnSheetMetalCmd.py" line="288"/>
-        <source>Base Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SketchOnSheetMetalCmd.py" line="290"/>
-        <source>Sketch on Sheetmetal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SketchOnSheetMetalCmd.py" line="292"/>
-        <source>Gap from Left Side</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="434"/>
-        <source>Corner Relief Type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="438"/>
-        <source>Size of Shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="440"/>
-        <source>Size Ratio of Shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="444"/>
-        <source>Corner Relief Sketch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="446"/>
-        <source>Gap from side one</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalCornerReliefCmd.py" line="448"/>
-        <source>Gap from side two</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="139"/>
-        <source>Offset from Center of Face</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="141"/>
-        <source>Suppress Forming Feature</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="143"/>
-        <source>Tool Position Angle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="145"/>
-        <source>Thickness of Sheetmetal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="149"/>
-        <source>Forming Tool Object</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalFormingCmd.py" line="151"/>
-        <source>Point Sketch on Sheetmetal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalJunction.py" line="104"/>
-        <source>Junction Gap</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../SheetMetalRelief.py" line="151"/>
-        <source>Relief Size</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../SheetMetalRelief.py" line="189"/>
-        <source>Edit %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SheetMetal</name>
+    <message>
+        <location filename="../InitGui.py" line="52"/>
+        <source>Sheet Metal</source>
+        <translation type="unfinished"></translation>
+    </message>
     <message>
         <location filename="../InitGui.py" line="54"/>
         <source>Sheet Metal workbench allows for designing and unfolding sheet metal parts</source>
@@ -459,11 +729,6 @@
     <message>
         <location filename="../InitGui.py" line="96"/>
         <source>Sheet Me&amp;tal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../InitGui.py" line="52"/>
-        <source>Sheet Metal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/SheetMetal_es-ar.ts
+++ b/translations/SheetMetal_es-ar.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es-AR" sourcelanguage="en">
+<TS version="2.1" language="es_AR" sourcelanguage="en">
 <context>
     <name>Gui::Dialog::DlgSettingsDraft</name>
     <message>

--- a/translations/SheetMetal_es-es.ts
+++ b/translations/SheetMetal_es-es.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es-es" sourcelanguage="en">
+<TS version="2.1" language="es_ES" sourcelanguage="en">
 <context>
     <name>Gui::Dialog::DlgSettingsDraft</name>
     <message>

--- a/translations/SheetMetal_pt-pt.ts
+++ b/translations/SheetMetal_pt-pt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt-pt" sourcelanguage="en_US">
+<TS version="2.1" language="pt_PT" sourcelanguage="en_US">
 <context>
     <name>Gui::Dialog::DlgSettingsDraft</name>
     <message>

--- a/translations/update_translation.sh
+++ b/translations/update_translation.sh
@@ -2,9 +2,9 @@
 
 # --------------------------------------------------------------------------------------------------
 #
-# Update translation files
+# Create, update and release translation files.
 #
-# Supported locales on FreeCAD <2024-01-20, FreeCADGui.supportedLocales(), total=40>:
+# Supported locales on FreeCAD <2024-03-13, FreeCADGui.supportedLocales(), total=43>:
 # 	{'English': 'en', 'Afrikaans': 'af', 'Arabic': 'ar', 'Basque': 'eu', 'Belarusian': 'be',
 # 	'Bulgarian': 'bg', 'Catalan': 'ca', 'Chinese Simplified': 'zh-CN',
 # 	'Chinese Traditional': 'zh-TW', 'Croatian': 'hr', 'Czech': 'cs', 'Dutch': 'nl',
@@ -16,21 +16,36 @@
 # 	'Slovenian': 'sl', 'Spanish': 'es-ES', 'Spanish, Argentina': 'es-AR', 'Swedish': 'sv-SE',
 # 	'Turkish': 'tr', 'Ukrainian': 'uk', 'Valencian': 'val-ES', 'Vietnamese': 'vi'}
 #
-# NOTE: WORKFLOW
-# 0. Install Qt tools
+# NOTE: PREPARATION
+# - Install Qt tools
 # 	Debian-based (e.g., Ubuntu): $ sudo apt-get install qttools5-dev-tools pyqt6-dev-tools
 # 	Fedora-based: $ sudo dnf install qt6-linguist qt6-devel
 # 	Arch-based: $ sudo pacman -S qt6-tools python-pyqt6
-# 1. Make the script executable
+# - Make the script executable
 # 	$ chmod +x update_translation.sh
-# 2. Execute the script passing the locale code as first parameter
-# 	The script has to be executed within the `resources/translations` directory
-# 	Only update the files you're translating!
-# 	$ ./update_translation.sh es-ES
-# 3. Do the translation via Qt Linguist and use `File>Release`
-# 4. If releasing with the script execute the script passing the locale code as first parameter
-# 	and use '-r' flag next
-# 	$ ./update_translation.sh es-ES -r
+# - The script has to be executed within the `translations` directory.
+# 	Executing the script with no flags involes the help.
+# 	$ ./update_translation.sh
+#
+# NOTE: WORKFLOW TRANSLATOR (LOCAL)
+# - Execute the script passing the `-u` flag plus locale code as argument
+# 	Only update the file(s) you're translating!
+# 	$ ./update_translation.sh -u es-ES
+# - Do the translation via Qt Linguist and use `File>Release`
+# - If releasing with the script execute it passing the `-r` flag
+# 	plus locale code as argument
+# 	$ ./update_translation.sh -r es-ES
+#
+# NOTE: WORKFLOW MAINTAINER (CROWDIN)
+# - Execute the script passing the '-U' flag
+# 	$ ./update_translation.sh -U
+# - Upload the updated file to Crowdin and wait for translators do their thing ;-)
+# - Once done, download the translated files, copy them to `translations`
+# 	and release all the files to update the changes
+# 	$ ./update_translation.sh -R
+#
+# The usage of `pylupdate6` is preferred over 'pylupdate5' when extracting text strings from
+# 	Python files. Also using `lupdate` from Qt6 is possible.
 #
 # --------------------------------------------------------------------------------------------------
 
@@ -38,13 +53,14 @@ supported_locales=(
 	"en" "af" "ar" "eu" "be" "bg" "ca" "zh-CN" "zh-TW" "hr"
 	"cs" "nl" "fil" "fi" "fr" "gl" "ka" "de" "el" "hu"
 	"id" "it" "ja" "kab" "ko" "lt" "no" "pl" "pt-PT" "pt-BR"
-	"ro" "ru" "sr" "es-ES" "es-AR" "sv-SE" "tr" "uk" "val-ES" "vi"
+	"ro" "ru" "sr" "sr-CS" "sk" "sl" "es-ES" "es-AR" "sv-SE" "tr"
+	"uk" "val-ES" "vi"
 )
 
 is_locale_supported() {
 	local locale="$1"
 	for supported_locale in "${supported_locales[@]}"; do
-		if [[ "${supported_locale,,}" == "$locale" ]]; then
+		if [[ "$supported_locale" == "$locale" ]]; then
 			return 0
 		fi
 	done
@@ -52,66 +68,99 @@ is_locale_supported() {
 }
 
 get_strings() {
-	# Get translatable strings from ../ui/*.ui Qt Designer files
-	lupdate ../*.ui -ts uifiles.ts -no-obsolete
-	# Get translatable strings from ../*.py Python files
+	# Get translatable strings from Qt Designer files
+	lupdate ../BaseShapeOptions.ui ../SMprefs.ui \
+		../UnfoldOptions.ui \
+		-ts uifiles.ts -no-obsolete
+	# Get translatable strings from Python files
+	# pylupdate5 ../*.py -ts pyfiles.ts -verbose
 	pylupdate6 ../*.py -ts pyfiles.ts
-}
-
-delete_files() {
-	# Delete files that are no longer needed
-	rm uifiles.ts
-	rm pyfiles.ts
-	rm -f _${WB}.ts
-}
-
-add_new_locale() {
-	echo -e "\033[1;33m\n\t<<< Creating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
-	get_strings
-	# Join strings from Qt Designer and Python files
-	# Add generic file
-	lconvert -i uifiles.ts pyfiles.ts -o ${WB}.ts
-	# Add specified locale file
-	lconvert -source-language en -target-language $LOCALE \
-		-i uifiles.ts pyfiles.ts -o ${WB}_${LOCALE}.ts
+	lconvert -i pyfiles.ts uifiles.ts -o _${WB}.ts -sort-contexts -no-obsolete -verbose
 }
 
 update_locale() {
-	echo -e "\033[1;32m\n\t<<< Updating '${WB}_${LOCALE}.ts' file >>>\n\033[m"
-	get_strings
-	# Join strings from Qt Designer and Python files
-	lconvert -i uifiles.ts pyfiles.ts -o _${WB}.ts
-	# Join newly created file with older file (-no-obsolete)
-	# Update generic file
-	lconvert -i _${WB}.ts ${WB}.ts -o ${WB}.ts
-	# Update specified locale file
-	lconvert -source-language en -target-language $LOCALE \
-		-i _${WB}.ts ${WB}_${LOCALE}.ts -o ${WB}_${LOCALE}.ts
+	local locale="$1"
+	local u=${locale:+_} # Conditional underscore
+
+	# NOTE: Execute the right commands depending on:
+	# - if the file already exists and
+	# - if it's a locale file or the main, agnostic one
+	if [ ! -f "${WB}${u}${locale,,}.ts" ]; then
+		echo -e "\033[1;34m\n\t<<< Creating '${WB}${u}${locale,,}.ts' file >>>\n\033[m"
+		get_strings
+		if [ "$locale" == "" ]; then
+			lconvert -i _${WB}.ts -o ${WB}.ts
+		else
+			lconvert -source-language en -target-language "${locale//-/_}" \
+				-i _${WB}.ts -o ${WB}_${locale,,}.ts
+		fi
+	else
+		echo -e "\033[1;34m\n\t<<< Updating '${WB}${u}${locale,,}.ts' file >>>\n\033[m"
+		get_strings
+		if [ "$locale" == "" ]; then
+			lconvert -i _${WB}.ts ${WB}.ts -o ${WB}.ts
+		else
+			lconvert -source-language en -target-language "${locale//-/_}" \
+				-i _${WB}.ts ${WB}_${locale,,}.ts -o ${WB}_${locale,,}.ts
+		fi
+	fi
+
+	# Delete files that are no longer needed
+	rm -f pyfiles.ts uifiles.ts _${WB}.ts
 }
 
-release_translation() {
-	# Release translation (creation of *.qm file from *.ts file)
-	lrelease ${WB}_${LOCALE}.ts
+release_locale() {
+	# Release locale (creation of *.qm file from *.ts file)
+	local locale="$1"
+	lrelease ${WB}_${locale}.ts
+}
+
+help() {
+	echo -e "\nDescription:"
+	echo -e "\tCreate, update and release translation files."
+	echo -e "\nUsage:"
+	echo -e "\t./update_translation.sh [-R] [-U] [-r <locale>] [-u <locale>]"
+	echo -e "\nFlags:"
+	echo -e "  -R\n\tRelease all locales"
+	echo -e "  -U\n\tUpdate main translation file (locale agnostic)"
+	echo -e "  -r <locale>\n\tRelease the specified locale"
+	echo -e "  -u <locale>\n\tUpdate strings for the specified locale"
 }
 
 # Main function ------------------------------------------------------------------------------------
 
 WB="SheetMetal"
-# Convert to lowercase
-LOCALE="${1,,}"
 
-if is_locale_supported "$LOCALE"; then
-	if [ "$2" == "-r" ]; then
-		release_translation
+if [ $# -eq 0 ]; then
+	help
+elif [ $# -eq 1 ]; then
+	if [ "$1" == "-R" ]; then
+		find . -type f -name '*_*.ts' | while IFS= read -r file; do
+			# Release all locales
+			lrelease $file
+			echo
+		done
+	elif [ "$1" == "-U" ]; then
+		# Update main file (agnostic)
+		update_locale
 	else
-		if [ ! -f "${WB}_${LOCALE}.ts" ]; then
-			add_new_locale
-		else
+		help
+	fi
+elif [ $# -eq 2 ]; then
+	LOCALE="$2"
+	if is_locale_supported "$LOCALE"; then
+		if [ "$1" == "-r" ]; then
+			# Release locale
+			release_locale "$LOCALE"
+		elif [ "$1" == "-u" ]; then
+			# Update main & locale files
 			update_locale
+			update_locale "$LOCALE"
 		fi
-		delete_files
+	else
+		echo "Verify your language code. Case sensitive."
+		echo "If it's correct ask a maintainer to add support for your language on FreeCAD."
 	fi
 else
-	echo "Verify your language code. Case sensitive."
-	echo "If it's correct ask a maintainer to add support for your language on FreeCAD."
+	help
 fi


### PR DESCRIPTION
Directly assigning the content of the text of the enum to the enum causes problems when the
enum elements are translated.

- Copy the enum text to temp variable and if needed make replacement to original keys from
  global list using the current enum index.
- Simplify "if"s using lists

Fix https://github.com/shaise/FreeCAD_SheetMetal/issues/315