### PR TITLE
Discard unneeded int casts in getStandardButtons methods

### DIFF
--- a/SheetMetalBend.py
+++ b/SheetMetalBend.py
@@ -347,7 +347,7 @@ class SMBendTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def update(self):
       'fills the treewidget'

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1784,7 +1784,7 @@ class SMBendWallTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def update(self):
         "fills the treewidget"

--- a/SheetMetalExtendCmd.py
+++ b/SheetMetalExtendCmd.py
@@ -539,7 +539,7 @@ class SMBendWallTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def update(self):
       'fills the treewidget'

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -392,7 +392,7 @@ class SMFormingWallTaskPanel:
       return True
 
     def getStandardButtons(self):
-      return int(QtGui.QDialogButtonBox.Ok)
+      return QtGui.QDialogButtonBox.Ok
 
     def update(self):
       'fills the treewidget'

--- a/SheetMetalJunction.py
+++ b/SheetMetalJunction.py
@@ -306,7 +306,7 @@ class SMJunctionTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def update(self):
       'fills the treewidget'

--- a/SheetMetalRelief.py
+++ b/SheetMetalRelief.py
@@ -354,7 +354,7 @@ class SMReliefTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def update(self):
       'fills the treewidget'


### PR DESCRIPTION
Because `QtWidgets.QDialogButtonBox.StandardButtons` are already converted into `int`s in FreeCAD's `Gui::TaskDialogPython::getStandardButtons`, such conversions in workbench code aren't needed. Also this fixes compatibility with PySide6.

https://github.com/FreeCAD/FreeCAD/blob/b9bfa5c5507506e4515816414cd27f4851d00489/src/Gui/TaskView/TaskDialogPython.cpp#L736-L754
