### PR TITLE
Make parameter `shapeType` enum translatable

### DIFF
--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -388,6 +388,14 @@ class SMBaseShape:
         if not restored:
             return smElementMapVersion + ver
 
+    def onChanged(self, fp, prop):
+        if prop == "shapeType":
+            flat = base_shape_types.index(fp.shapeType) == 0
+            hat_box = base_shape_types.index(fp.shapeType) in [4, 5]
+            fp.setEditorMode("radius", flat)
+            fp.setEditorMode("height", flat)
+            fp.setEditorMode("flangeWidth", not hat_box)
+
     def execute(self, fp):
         self._addVerifyProperties(fp)
         s = smCreateBaseShape(


### PR DESCRIPTION
- Strings now also appear translated in the Property View, the same as in the dockable UI
- Fix hard-coded strings on `updateEnableState()` method
![image](https://github.com/shaise/FreeCAD_SheetMetal/assets/53124818/11b465b3-075a-49c0-ab6a-309fe95fac11)
