### PR TITLE
Make unused parameters `readonly` when are not used

### DIFF
--- a/SheetMetalBaseShapeCmd.py
+++ b/SheetMetalBaseShapeCmd.py
@@ -371,6 +371,14 @@ class SMBaseShape:
         if not restored:
             return smElementMapVersion + ver
 
+    def onChanged(self, fp, prop):
+        if prop == "shapeType":
+            flat = fp.shapeType == "Flat"
+            hat_box = fp.shapeType in ["Hat", "Box"]
+            fp.setEditorMode("radius", flat)
+            fp.setEditorMode("height", flat)
+            fp.setEditorMode("flangeWidth", not hat_box)
+
     def execute(self, fp):
         self._addVerifyProperties(fp)
         s = smCreateBaseShape(type = fp.shapeType, thickness = fp.thickness.Value,


### PR DESCRIPTION
Same behaviour as in the dockable UI

Example when "Flat" can't edit radius.
![image](https://github.com/shaise/FreeCAD_SheetMetal/assets/53124818/2f996364-91ff-4dfe-8a18-b565b4b94cd6)
