### PR TITLE
[SheetMetalUnfolder] Sketch colors must be integers...

### DIFF
--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -3254,7 +3254,7 @@ def generateSketch(edges, name, color):
         sk = SMmakeSketchfromEdges(p.Edges, name)
 
     if FreeCAD.GuiUp:
-        rgb_color = tuple(float(int(color[i : i + 2], 16)) for i in (1, 3, 5))
+        rgb_color = tuple(int(color[i : i + 2], 16) for i in (1, 3, 5))
         sk.ViewObject.LineColor = rgb_color
         sk.ViewObject.PointColor = rgb_color
 


### PR DESCRIPTION
...not floats. Assumption: the new Materials system has changed this so I made sure it still works with 0.21.x and it does.

Currently my box puts out loads of `QColor::setRgb: RGB parameters out of range` warnings, this is fixed with the PR.
