### PR TITLE
Fix lost of topo naming

### DIFF
--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -287,9 +287,12 @@ def smGetFace(Faces, obj):
 
 def LineExtend(edge, distance1, distance2):
     # Extend a ine by given distances
-    return edge.Curve.toShape(
+    result = edge.Curve.toShape(
         edge.FirstParameter - distance1, edge.LastParameter + distance2
     )
+    if hasattr(result, "mapShapes"):
+        result.mapShapes([(edge, result)], [])
+    return result
 
 
 def getParallel(edge1, edge2):


### PR DESCRIPTION
Related realthunder/FreeCAD#1013. The root cause is lost of topo naming due a bug in `mapShapes()` and is fixed in [here](https://github.com/realthunder/FreeCAD/commit/aa1aa00ae4784ebfae85407e8bdc932c456858cf). There is also a minor problem in your code, hence the PR here.

In my branch, you can check if topo naming is working by mouse over highlight. It should show the added shape.

![Screenshot from 2024-08-19 20-58-53](https://github.com/user-attachments/assets/b77cb03d-9b3e-47a8-b24b-7df648eb4447)
