### PR TITLE
Bend perforation

### DIFF
--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -176,7 +176,22 @@ def smMakeReliefFace(edge, dir, gap, reliefW, reliefD, reliefType, op=""):
     return face
 
 
-def smMakePerforationFace(edge, dir, bendR, bendA, perforationAngle, flipped, extLen, gap1, gap2, lenIPerf1, lenIPerf2, lenPerf, lenNPerf, op=""):
+def smMakePerforationFace(
+        edge,
+        dir,
+        bendR,
+        bendA,
+        perforationAngle,
+        flipped,
+        extLen,
+        gap1,
+        gap2,
+        lenIPerf1,
+        lenIPerf2,
+        lenPerf,
+        lenNPerf,
+        op="",
+):
     L0 = (edge.LastParameter - gap2 - lenIPerf2) - (edge.FirstParameter + gap1 + lenIPerf1)
     Lp = lenPerf
     Ln = lenNPerf
@@ -1364,13 +1379,32 @@ def smBend(
             # Remove perforation
             if perforate:
                 #CHECK I'm not sure about flipped - the main one gets overwritten for each sublist item
-                perfFace = smMakePerforationFace(lenEdge, thkDir, bendR, bendA, perforationAngle, flipped, thk, gap1, gap2, perforationInitialLength, perforationInitialLength, perforationMaxLength, nonperforationMaxLength, op="SMR")
+                perfFace = smMakePerforationFace(
+                    lenEdge,
+                    thkDir,
+                    bendR,
+                    bendA,
+                    perforationAngle,
+                    flipped,
+                    thk,
+                    gap1,
+                    gap2,
+                    perforationInitialLength,
+                    perforationInitialLength,
+                    perforationMaxLength,
+                    nonperforationMaxLength,
+                    op="SMR",
+                )
                 # Part.show(perfFace)
                 #CHECK 'Part.Compound' object has no attribute 'normalAt' ; might need it
                 # if perfFace.normalAt(0, 0) != FaceDir:
                 #     perfFace.reverse()
                 if perforationAngle > 0.0:
-                    perfFace = perfFace.rotate(revAxisP, revAxisV, (bendA/2)-(perforationAngle/2))
+                    perfFace = perfFace.rotate(
+                        revAxisP,
+                        revAxisV,
+                        (bendA/2)-(perforationAngle/2)
+                    )
                     perfSolid = perfFace.revolve(revAxisP, revAxisV, perforationAngle)
                 else:
                     perfSolid = perfFace.revolve(revAxisP, revAxisV, bendA)
@@ -1399,7 +1433,22 @@ def smBend(
 
             # Remove perforation
             if perforate:
-                perfFace = smMakePerforationFace(lenEdge, thkDir, bendR, bendA, perforationAngle, flipped, thk, gap1, gap2, perforationInitialLength, perforationInitialLength, perforationMaxLength, nonperforationMaxLength, op="SMR")
+                perfFace = smMakePerforationFace(
+                    lenEdge,
+                    thkDir,
+                    bendR,
+                    bendA,
+                    perforationAngle,
+                    flipped,
+                    thk,
+                    gap1,
+                    gap2,
+                    perforationInitialLength,
+                    perforationInitialLength,
+                    perforationMaxLength,
+                    nonperforationMaxLength,
+                    op="SMR",
+                )
                 #CHECK 'Part.Compound' object has no attribute 'normalAt' ; might need it
                 # if perfFace.normalAt(0, 0) != FaceDir:
                 #     perfFace.reverse()
@@ -1636,7 +1685,7 @@ class SMBendWall:
             False,
             "ParametersPerforation",
         )
-        smAddAngleProperty( #THINK I initially tried for width, but that was hard, and its merits vs angle is debatable in view of bend angle rather than length.
+        smAddAngleProperty(
             obj,
             "perforationAngle",
             FreeCAD.Qt.translate("App::Property", "Perforation Angle"),

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1797,10 +1797,10 @@ class SMBendWall:
                 maxExtendGap=fp.maxExtendDist.Value,
                 LengthSpec=fp.LengthSpec,
                 perforate=fp.Perforate,
-                perforationAngle=fp.perforationAngle,
-                perforationInitialLength=fp.perforationInitialLength,
-                perforationMaxLength=fp.perforationMaxLength,
-                nonperforationMaxLength=fp.nonperforationMaxLength,
+                perforationAngle=fp.perforationAngle.Value,
+                perforationInitialLength=fp.perforationInitialLength.Value,
+                perforationMaxLength=fp.perforationMaxLength.Value,
+                nonperforationMaxLength=fp.nonperforationMaxLength.Value,
             )
             faces = smGetFace(f, s)
             face = faces

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -917,6 +917,11 @@ def smBend(
     sketch=None,
     extendType="Simple",
     LengthSpec="Leg",
+    perforate=False,
+    perforationWidth=5.0,
+    perforationInitialLength=5.0,
+    perforationMaxLength=5.0,
+    nonperforationMaxLength=5.0,
 ):
     # if sketch is as wall
     sketches = False
@@ -1530,6 +1535,48 @@ class SMBendWall:
             None,
             "ParametersEx3",
         )
+        smAddBoolProperty(
+            obj,
+            "Perforate",
+            FreeCAD.Qt.translate("App::Property", "Enable Perforation"),
+            False,
+            "ParametersPerforation",
+        )
+        smAddBoolProperty(
+            obj,
+            "Perforate",
+            FreeCAD.Qt.translate("App::Property", "Enable Perforation"),
+            False,
+            "ParametersPerforation",
+        )
+        smAddLengthProperty( #DUMMY Not sure if this is needed or useful, should probably match radius, maybe
+            obj,
+            "perforationWidth",
+            FreeCAD.Qt.translate("App::Property", "Perforation Width"),
+            5.0, # Shouldn't this have like, units or st?
+            "ParametersPerforation",
+        )
+        smAddLengthProperty(
+            obj,
+            "perforationInitialLength",
+            FreeCAD.Qt.translate("App::Property", "Initial Perforation Length"),
+            5.0,
+            "ParametersPerforation",
+        )
+        smAddLengthProperty(
+            obj,
+            "perforationMaxLength",
+            FreeCAD.Qt.translate("App::Property", "Perforation Max Length"),
+            5.0,
+            "ParametersPerforation",
+        )
+        smAddLengthProperty(
+            obj,
+            "nonperforationMaxLength",
+            FreeCAD.Qt.translate("App::Property", "Non-Perforation Max Length"),
+            5.0,
+            "ParametersPerforation",
+        )
 
     def getElementMapVersion(self, _fp, ver, _prop, restored):
         if not restored:
@@ -1613,6 +1660,11 @@ class SMBendWall:
                 mingap=fp.minGap.Value,
                 maxExtendGap=fp.maxExtendDist.Value,
                 LengthSpec=fp.LengthSpec,
+                perforate=fp.Perforate,
+                perforationWidth=fp.perforationWidth,
+                perforationInitialLength=fp.perforationInitialLength,
+                perforationMaxLength=fp.perforationMaxLength,
+                nonperforationMaxLength=fp.nonperforationMaxLength,
             )
             faces = smGetFace(f, s)
             face = faces

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -190,20 +190,26 @@ def smMakePerforationFace(edge, dir, bendR, bendA, perforationAngle, flipped, ex
     extAngle = (perforationAngle - bendA) / 2;
     S = (1 / math.cos(extAngle * (2*math.pi/360)))
 
+    pivotL = -bendR
+    swingL = extLen + (S-1)*(bendR+extLen)
+    if not flipped:
+        pivotL = extLen - pivotL
+        swingL = extLen - swingL
+
     # Initial perf, near
-    p1 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * -bendR
-    p2 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * -bendR
-    p3 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
-    p4 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
+    p1 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * pivotL
+    p2 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * pivotL
+    p3 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * swingL
+    p4 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * swingL
     w = Part.makePolygon([p1, p2, p3, p4, p1])
     face = Part.Face(w)
     totalFace = face
 
     # Initial perf, far
-    p1 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * -bendR
-    p2 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * -bendR
-    p3 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
-    p4 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
+    p1 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * pivotL
+    p2 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * pivotL
+    p3 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * swingL
+    p4 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * swingL
     w = Part.makePolygon([p1, p2, p3, p4, p1])
     face = Part.Face(w)
     totalFace = totalFace.fuse(face)
@@ -211,10 +217,10 @@ def smMakePerforationFace(edge, dir, bendR, bendA, perforationAngle, flipped, ex
     # Perforations, inner
     for i in range(P):
         x = (edge.FirstParameter + gap1 + lenIPerf1) + (Ln * F * (i+1)) + (Lp * F * i)
-        p1 = edge.valueAt(x) + dir.normalize() * -bendR
-        p2 = edge.valueAt(x + Lp*F) + dir.normalize() * -bendR
-        p3 = edge.valueAt(x + Lp*F) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
-        p4 = edge.valueAt(x) + dir.normalize() * (extLen + (S-1)*(bendR+extLen))
+        p1 = edge.valueAt(x) + dir.normalize() * pivotL
+        p2 = edge.valueAt(x + Lp*F) + dir.normalize() * pivotL
+        p3 = edge.valueAt(x + Lp*F) + dir.normalize() * swingL
+        p4 = edge.valueAt(x) + dir.normalize() * swingL
         w = Part.makePolygon([p1, p2, p3, p4, p1])
         face = Part.Face(w)
         totalFace = totalFace.fuse(face)
@@ -1357,8 +1363,9 @@ def smBend(
 
             # Remove perforation
             if perforate:
+                #CHECK I'm not sure about flipped - the main one gets overwritten for each sublist item
                 perfFace = smMakePerforationFace(lenEdge, thkDir, bendR, bendA, perforationAngle, flipped, thk, gap1, gap2, perforationInitialLength, perforationInitialLength, perforationMaxLength, nonperforationMaxLength, op="SMR")
-                Part.show(perfFace)
+                # Part.show(perfFace)
                 #CHECK 'Part.Compound' object has no attribute 'normalAt' ; might need it
                 # if perfFace.normalAt(0, 0) != FaceDir:
                 #     perfFace.reverse()
@@ -1367,7 +1374,7 @@ def smBend(
                     perfSolid = perfFace.revolve(revAxisP, revAxisV, perforationAngle)
                 else:
                     perfSolid = perfFace.revolve(revAxisP, revAxisV, bendA)
-                Part.show(perfSolid)
+                # Part.show(perfSolid)
                 resultSolid = resultSolid.cut(perfSolid)
 
         # Produce unfold Solid

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -986,11 +986,11 @@ def smBend(
     sketch=None,
     extendType="Simple",
     LengthSpec="Leg",
-    perforate=False,
-    perforationAngle=0.0,
-    perforationInitialLength=5.0,
-    perforationMaxLength=5.0,
-    nonperforationMaxLength=5.0,
+    Perforate=False,
+    PerforationAngle=0.0,
+    PerforationInitialLength=5.0,
+    PerforationMaxLength=5.0,
+    NonperforationMaxLength=5.0,
 ):
     # if sketch is as wall
     sketches = False
@@ -1377,35 +1377,35 @@ def smBend(
                 # Part.show(resultSolid,"resultSolid")
 
             # Remove perforation
-            if perforate:
+            if Perforate:
                 #CHECK I'm not sure about flipped - the main one gets overwritten for each sublist item
                 perfFace = smMakePerforationFace(
                     lenEdge,
                     thkDir,
                     bendR,
                     bendA,
-                    perforationAngle,
+                    PerforationAngle,
                     flipped,
                     thk,
                     gap1,
                     gap2,
-                    perforationInitialLength,
-                    perforationInitialLength,
-                    perforationMaxLength,
-                    nonperforationMaxLength,
+                    PerforationInitialLength,
+                    PerforationInitialLength,
+                    PerforationMaxLength,
+                    NonperforationMaxLength,
                     op="SMR",
                 )
                 # Part.show(perfFace)
                 #CHECK 'Part.Compound' object has no attribute 'normalAt' ; might need it
                 # if perfFace.normalAt(0, 0) != FaceDir:
                 #     perfFace.reverse()
-                if perforationAngle > 0.0:
+                if PerforationAngle > 0.0:
                     perfFace = perfFace.rotate(
                         revAxisP,
                         revAxisV,
-                        (bendA/2)-(perforationAngle/2)
+                        (bendA/2)-(PerforationAngle/2)
                     )
-                    perfSolid = perfFace.revolve(revAxisP, revAxisV, perforationAngle)
+                    perfSolid = perfFace.revolve(revAxisP, revAxisV, PerforationAngle)
                 else:
                     perfSolid = perfFace.revolve(revAxisP, revAxisV, bendA)
                 # Part.show(perfSolid)
@@ -1432,28 +1432,28 @@ def smBend(
                 resultSolid = resultSolid.fuse(wallSolid)
 
             # Remove perforation
-            if perforate:
+            if Perforate:
                 perfFace = smMakePerforationFace(
                     lenEdge,
                     thkDir,
                     bendR,
                     bendA,
-                    perforationAngle,
+                    PerforationAngle,
                     flipped,
                     thk,
                     gap1,
                     gap2,
-                    perforationInitialLength,
-                    perforationInitialLength,
-                    perforationMaxLength,
-                    nonperforationMaxLength,
+                    PerforationInitialLength,
+                    PerforationInitialLength,
+                    PerforationMaxLength,
+                    NonperforationMaxLength,
                     op="SMR",
                 )
                 #CHECK 'Part.Compound' object has no attribute 'normalAt' ; might need it
                 # if perfFace.normalAt(0, 0) != FaceDir:
                 #     perfFace.reverse()
-                if perforationAngle > 0.0:
-                    perfUnfoldLength = (bendR + kfactor * thk) * perforationAngle * math.pi / 180.0
+                if PerforationAngle > 0.0:
+                    perfUnfoldLength = (bendR + kfactor * thk) * PerforationAngle * math.pi / 180.0
                     perfFace = perfFace.translate(FaceDir * ((unfoldLength/2)-(perfUnfoldLength/2)))
                     perfSolid = perfFace.extrude(FaceDir * perfUnfoldLength)
                 else:
@@ -1678,37 +1678,30 @@ class SMBendWall:
             False,
             "ParametersPerforation",
         )
-        smAddBoolProperty(
-            obj,
-            "Perforate",
-            FreeCAD.Qt.translate("App::Property", "Enable Perforation"),
-            False,
-            "ParametersPerforation",
-        )
         smAddAngleProperty(
             obj,
-            "perforationAngle",
+            "PerforationAngle",
             FreeCAD.Qt.translate("App::Property", "Perforation Angle"),
             0.0,
             "ParametersPerforation",
         )
         smAddLengthProperty(
             obj,
-            "perforationInitialLength",
+            "PerforationInitialLength",
             FreeCAD.Qt.translate("App::Property", "Initial Perforation Length"),
             5.0,
             "ParametersPerforation",
         )
         smAddLengthProperty(
             obj,
-            "perforationMaxLength",
+            "PerforationMaxLength",
             FreeCAD.Qt.translate("App::Property", "Perforation Max Length"),
             5.0,
             "ParametersPerforation",
         )
         smAddLengthProperty(
             obj,
-            "nonperforationMaxLength",
+            "NonperforationMaxLength",
             FreeCAD.Qt.translate("App::Property", "Non-Perforation Max Length"),
             5.0,
             "ParametersPerforation",
@@ -1796,11 +1789,11 @@ class SMBendWall:
                 mingap=fp.minGap.Value,
                 maxExtendGap=fp.maxExtendDist.Value,
                 LengthSpec=fp.LengthSpec,
-                perforate=fp.Perforate,
-                perforationAngle=fp.perforationAngle.Value,
-                perforationInitialLength=fp.perforationInitialLength.Value,
-                perforationMaxLength=fp.perforationMaxLength.Value,
-                nonperforationMaxLength=fp.nonperforationMaxLength.Value,
+                Perforate=fp.Perforate,
+                PerforationAngle=fp.PerforationAngle.Value,
+                PerforationInitialLength=fp.PerforationInitialLength.Value,
+                PerforationMaxLength=fp.PerforationMaxLength.Value,
+                NonperforationMaxLength=fp.NonperforationMaxLength.Value,
             )
             faces = smGetFace(f, s)
             face = faces


### PR DESCRIPTION
I added the ability to perforate bends, for easy folding.  I tried to make it robust, and it seems to work pretty reliably, though there's a few uncertainties and caveats:
1. In smBend, the `flipped` parameter passed in gets overwritten on each iteration of the sublist.  I don't really understand why or whether there's implications - but it seems to work, so.  (I think it would only matter when the perforation angle is different than the bend angle, fyi.)
2. In the sections labeled "Produce bend Solid" and "Produce unfold Solid" there are blocks
```
if revFace.normalAt(0, 0) != FaceDir:
    revFace.reverse()
```
However, the perforation face I create is composed of multiple faces, so if I try to do the same thing I get error `'Part.Compound' object has no attribute 'normalAt'`.  I don't know why the faces would need to be reversed, so I don't know whether it's a problem here, and it seems to work, so.
3. I'm getting a "Sheet thickness invalid" error when I unfold a shape with nonzero gaps _and_ perforation angle sufficiently greater than bend angle...but hopefully that's really rare in practice, especially because people would usually want perforation the same size as the bend (or less, even), I think.

Overall it seems pretty reliable, though.  I made a D20.
Without perforation:
![20240904_030145](https://github.com/user-attachments/assets/fe46d9b6-b624-4956-8ee9-4de5f076c705)
With perforation:
![20240912_035532](https://github.com/user-attachments/assets/c31dfb18-01e3-439f-84e1-0abc780014f4)
It bent a lot more easily and accurately with the perforations, naturally.

The size of the perforations is adjustable with perforationMaxLength and nonperforationMaxLength.

![Screenshot from 2024-09-14 12-25-10](https://github.com/user-attachments/assets/06b4e455-6dc2-4ac9-9095-52c7fb0a2eff)
