### PR TITLE
Permit 0-length initial perforation

### DIFF
--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -211,23 +211,30 @@ def smMakePerforationFace(
         pivotL = extLen - pivotL
         swingL = extLen - swingL
 
+    totalFace = None
+
     # Initial perf, near
-    p1 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * pivotL
-    p2 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * pivotL
-    p3 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * swingL
-    p4 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * swingL
-    w = Part.makePolygon([p1, p2, p3, p4, p1])
-    face = Part.Face(w)
-    totalFace = face
+    if lenIPerf1 > 0:
+        p1 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * pivotL
+        p2 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * pivotL
+        p3 = edge.valueAt(edge.FirstParameter + gap1 + lenIPerf1) + dir.normalize() * swingL
+        p4 = edge.valueAt(edge.FirstParameter + gap1) + dir.normalize() * swingL
+        w = Part.makePolygon([p1, p2, p3, p4, p1])
+        face = Part.Face(w)
+        totalFace = face
 
     # Initial perf, far
-    p1 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * pivotL
-    p2 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * pivotL
-    p3 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * swingL
-    p4 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * swingL
-    w = Part.makePolygon([p1, p2, p3, p4, p1])
-    face = Part.Face(w)
-    totalFace = totalFace.fuse(face)
+    if lenIPerf2 > 0:
+        p1 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * pivotL
+        p2 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * pivotL
+        p3 = edge.valueAt(edge.LastParameter - gap2) + dir.normalize() * swingL
+        p4 = edge.valueAt(edge.LastParameter - gap2 - lenIPerf2) + dir.normalize() * swingL
+        w = Part.makePolygon([p1, p2, p3, p4, p1])
+        face = Part.Face(w)
+        if totalFace == None:
+            totalFace = face
+        else:
+            totalFace = totalFace.fuse(face)
 
     # Perforations, inner
     for i in range(P):
@@ -238,7 +245,10 @@ def smMakePerforationFace(
         p4 = edge.valueAt(x) + dir.normalize() * swingL
         w = Part.makePolygon([p1, p2, p3, p4, p1])
         face = Part.Face(w)
-        totalFace = totalFace.fuse(face)
+        if totalFace == None:
+            totalFace = face
+        else:
+            totalFace = totalFace.fuse(face)
 
     if hasattr(totalFace, "mapShapes"):
         totalFace.mapShapes([(edge, totalFace)], None, op)


### PR DESCRIPTION
Setting initial perforation length to 0 caused an error, described here: https://github.com/shaise/FreeCAD_SheetMetal/issues/372
I changed the code so it skips the initial perforations if the length is non-positive.