### PR TITLE
Update ExtrudedCutout.py for correcting the creation of faces from the sketch (now supports multiple cuts from a single sketch)

### DIFF
--- a/ExtrudedCutout.py
+++ b/ExtrudedCutout.py
@@ -144,7 +144,14 @@ class ExtrudedCutout:
                 raise Exception("No pairs of parallel faces with the specified thickness distance were found.")
 
             # Step 3: Extrude the cut sketch
-            myFace = Part.Face(cutSketch.Shape)
+            # Get all faces in sketch
+            skWiresList = cutSketch.Shape.Wires
+            myFacesList = []
+            for wire in skWiresList:
+                myFace = Part.Face(wire)
+                myFacesList.append(myFace)
+
+            compFaces = Part.Compound(myFacesList)
 
             if ExtLength1 == 0 and ExtLength2 == 0:
                 raise Exception("Cut length cannot be zero for both sides.")
@@ -154,12 +161,13 @@ class ExtrudedCutout:
                 if ExtLength2 == 0:
                     ExtLength2 = (-ExtLength1)
 
-                ExtLength1 = myFace.Faces[0].normalAt(0, 0) * (-ExtLength1)
-                ExtLength2 = myFace.Faces[0].normalAt(0, 0) * ExtLength2
+                ExtLength1 = compFaces.Faces[0].normalAt(0, 0) * (-ExtLength1)
+                ExtLength2 = compFaces.Faces[0].normalAt(0, 0) * ExtLength2
 
-                myExtrusion1 = myFace.extrude(ExtLength1)
-                myExtrusion2 = myFace.extrude(ExtLength2)
+                myExtrusion1 = compFaces.extrude(ExtLength1)
+                myExtrusion2 = compFaces.extrude(ExtLength2)
                 myUnion = Part.Solid.fuse(myExtrusion1, myExtrusion2).removeSplitter()
+
                 myCommon = myUnion.common(shell)
 
             # Step 4: Find connected components and offset shapes


### PR DESCRIPTION
Before this fix, Extruded Cutout feature cannot create a cut when the wires from a single sketch creates more than one separate face.

Now, with this fix, a single sketch can have wires that create more than one separate face, thus allowing the creation of multiple cuts from a single sketch.

![image](https://github.com/user-attachments/assets/532ae018-de49-4801-81cd-bb31a0db809a)