### PR TITLE
Python 3.12.x fixes

### DIFF
--- a/SheetMetalKfactor.py
+++ b/SheetMetalKfactor.py
@@ -63,7 +63,7 @@ def _find_objects(objs, _filter):
 
 
 def getSpreadSheetNames():
-    material_sheet_regex_str = "material_([a-zA-Z0-9_\-\[\]\.]+)"
+    material_sheet_regex_str = r"material_([a-zA-Z0-9_\-\[\]\.]+)"
     material_sheet_regex = re.compile(material_sheet_regex_str)
 
     spreadsheets = findObjectsByTypeRecursive(
@@ -88,7 +88,7 @@ def getSpreadSheetNames():
 
 
 class KFactorLookupTable:
-    cell_regex = re.compile("^([A-Z]+)([0-9]+)$")
+    cell_regex = re.compile(r"^([A-Z]+)([0-9]+)$")
 
     def __init__(self, material_sheet):
         lookup_sheet = FreeCAD.ActiveDocument.getObjectsByLabel(material_sheet)
@@ -152,7 +152,7 @@ class KFactorLookupTable:
             if content == "Radius / Thickness":
                 key_cell = cell
             try:
-                m = re.search("(K-[fF]actor)\s?\(?([a-zA-Z]*)\)?", content)
+                m = re.search(r"(K-[fF]actor)\s?\(?([a-zA-Z]*)\)?", content)
                 if m:
                     value_cell = cell
                     k_factor_standard = m.group(2).lower() or None


### PR DESCRIPTION
In order to mitigate errors such as:

```
00:55:58  /home/username/.local/share/FreeCAD/Mod/sheetmetal/./SheetMetalKfactor.py:66: SyntaxWarning: invalid escape sequence '\-'
  material_sheet_regex_str = "material_([a-zA-Z0-9_\-\[\]\.]+)"
00:55:58  /home/username/.local/share/FreeCAD/Mod/sheetmetal/./SheetMetalKfactor.py:155: SyntaxWarning: invalid escape sequence '\s'
  m = re.search("(K-[fF]actor)\s?\(?([a-zA-Z]*)\)?", content)
```

this PR also maintains backwards compatibility to Python 3.8.x and those in between.
