### PR TITLE
Typos

### DIFF
--- a/Resources/panels/BaseShapeOptions.ui
+++ b/Resources/panels/BaseShapeOptions.ui
@@ -383,7 +383,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>height of base shape</string>
+        <string>Height of base shape</string>
        </property>
        <property name="decimals">
         <number>3</number>

--- a/Resources/panels/ExtrudedCutoutPanel.ui
+++ b/Resources/panels/ExtrudedCutoutPanel.ui
@@ -142,7 +142,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Symetric</string>
+            <string>Symmetric</string>
            </property>
           </item>
           <item>

--- a/Resources/panels/SolidCornerReliefPanel.ui
+++ b/Resources/panels/SolidCornerReliefPanel.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Add Cornner Relief on Solid</string>
+   <string>Add Corner Relief on Solid</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/Resources/translations/SheetMetal.ts
+++ b/Resources/translations/SheetMetal.ts
@@ -5,9 +5,9 @@
     <name>App::Property</name>
     <message>
         <location filename="../../SheetMetalBaseCmd.py" line="114"/>
-        <location filename="../../SheetMetalBend.py" line="109"/>
-        <location filename="../../SheetMetalCmd.py" line="1382"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="256"/>
+        <location filename="../../SheetMetalBend.py" line="122"/>
+        <location filename="../../SheetMetalCmd.py" line="1385"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="257"/>
         <source>Bend Radius</source>
         <translation type="unfinished"></translation>
     </message>
@@ -18,8 +18,7 @@
     </message>
     <message>
         <location filename="../../SheetMetalBaseCmd.py" line="122"/>
-        <location filename="../../SheetMetalCmd.py" line="1456"/>
-        <source>Relief Type</source>
+        <source>Bend Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -45,320 +44,565 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBend.py" line="112"/>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="450"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="276"/>
+        <location filename="../../SheetMetalBend.py" line="114"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="453"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="306"/>
         <source>Base object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1375"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="262"/>
-        <location filename="../../SheetMetalFormingCmd.py" line="120"/>
-        <location filename="../../SheetMetalJunction.py" line="71"/>
-        <location filename="../../SheetMetalRelief.py" line="119"/>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="269"/>
+        <location filename="../../SheetMetalCmd.py" line="1377"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="263"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="159"/>
+        <location filename="../../SheetMetalJunction.py" line="80"/>
+        <location filename="../../SheetMetalRelief.py" line="125"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="271"/>
         <source>Base Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1385"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="270"/>
+        <location filename="../../SheetMetalCmd.py" line="1388"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="298"/>
         <source>Length of Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1390"/>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="277"/>
+        <location filename="../../SheetMetalCmd.py" line="1393"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="279"/>
         <source>Gap from Left Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1396"/>
+        <location filename="../../SheetMetalCmd.py" line="1399"/>
         <source>Gap from Right Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1402"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="278"/>
+        <location filename="../../SheetMetalCmd.py" line="1405"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="279"/>
         <source>Invert Bend Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1406"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="260"/>
+        <location filename="../../SheetMetalCmd.py" line="1409"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="261"/>
         <source>Bend Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1411"/>
+        <location filename="../../SheetMetalCmd.py" line="1414"/>
         <source>Extend from Left Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1417"/>
+        <location filename="../../SheetMetalCmd.py" line="1420"/>
         <source>Extend from Right Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1423"/>
+        <location filename="../../SheetMetalCmd.py" line="1426"/>
         <source>Bend Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1429"/>
+        <location filename="../../SheetMetalCmd.py" line="1432"/>
         <source>Type of Length Specification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1435"/>
+        <location filename="../../SheetMetalCmd.py" line="1438"/>
         <source>Relief Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1442"/>
+        <location filename="../../SheetMetalCmd.py" line="1445"/>
         <source>Relief Depth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1449"/>
+        <location filename="../../SheetMetalCmd.py" line="1452"/>
         <source>Use Relief Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1464"/>
+        <location filename="../../SheetMetalCmd.py" line="1459"/>
+        <source>Relief Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../SheetMetalCmd.py" line="1467"/>
         <source>Relief Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1471"/>
+        <location filename="../../SheetMetalCmd.py" line="1474"/>
         <source>Bend Miter Angle from Left Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1478"/>
+        <location filename="../../SheetMetalCmd.py" line="1481"/>
         <source>Bend Miter Angle from Right Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1485"/>
+        <location filename="../../SheetMetalCmd.py" line="1488"/>
         <source>Auto Miter Minimum Gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1492"/>
+        <location filename="../../SheetMetalCmd.py" line="1495"/>
         <source>Auto Miter maximum Extend Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1499"/>
+        <location filename="../../SheetMetalCmd.py" line="1502"/>
         <source>Minimum Gap to Relief Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1506"/>
+        <location filename="../../SheetMetalCmd.py" line="1509"/>
         <source>Offset Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1513"/>
+        <location filename="../../SheetMetalCmd.py" line="1516"/>
         <source>Enable Auto Miter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1520"/>
+        <location filename="../../SheetMetalCmd.py" line="1523"/>
         <source>Shows Unfold View of Current Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1531"/>
+        <location filename="../../SheetMetalCmd.py" line="1534"/>
         <source>Location of Neutral Line. Caution: Using ANSI standards, not DIN.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1538"/>
+        <location filename="../../SheetMetalCmd.py" line="1541"/>
         <source>Flip Sketch Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1545"/>
+        <location filename="../../SheetMetalCmd.py" line="1548"/>
         <source>Invert Sketch Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1553"/>
+        <location filename="../../SheetMetalCmd.py" line="1556"/>
         <source>Sketch Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1561"/>
+        <location filename="../../SheetMetalCmd.py" line="1564"/>
         <source>Length of Wall List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1569"/>
+        <location filename="../../SheetMetalCmd.py" line="1572"/>
         <source>Bend Angle List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1576"/>
+        <location filename="../../SheetMetalCmd.py" line="1579"/>
         <source>Enable Perforation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1583"/>
+        <location filename="../../SheetMetalCmd.py" line="1586"/>
         <source>Perforation Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1590"/>
+        <location filename="../../SheetMetalCmd.py" line="1593"/>
         <source>Initial Perforation Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1597"/>
+        <location filename="../../SheetMetalCmd.py" line="1600"/>
         <source>Perforation Max Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="1604"/>
+        <location filename="../../SheetMetalCmd.py" line="1607"/>
         <source>Non-Perforation Max Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="440"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="443"/>
         <source>Corner Relief Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="454"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="457"/>
         <source>Size of Shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="456"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="459"/>
         <source>Size Ratio of Shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="460"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="274"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="463"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="275"/>
         <source>Neutral Axis Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="464"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="467"/>
         <source>Corner Relief Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="466"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="469"/>
         <source>Gap from side one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="470"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="473"/>
         <source>Gap from side two</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="272"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="302"/>
         <source>Gap from left side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="274"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="304"/>
         <source>Gap from right side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="278"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="294"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="310"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="333"/>
         <source>Wall Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="280"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="296"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="304"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="312"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="335"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="347"/>
         <source>Use Subtraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="282"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="316"/>
         <source>Offset for subtraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="284"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="298"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="320"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="339"/>
         <source>Use Refine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="266"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="267"/>
         <source>Bend Reference Line List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="270"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="271"/>
         <source>Invert Solid Bend Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="282"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="283"/>
         <source>Unfold Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="286"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="296"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="287"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="297"/>
         <source>Bend Line Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="112"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="145"/>
         <source>Offset from Center of Face</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="114"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="149"/>
         <source>Suppress Forming Feature</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="116"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="152"/>
         <source>Tool Position Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="118"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="156"/>
         <source>Thickness of Sheetmetal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="123"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="162"/>
         <source>Forming Tool Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="126"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="168"/>
         <source>Point Sketch on Sheetmetal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalJunction.py" line="69"/>
+        <location filename="../../SheetMetalJunction.py" line="77"/>
         <source>Junction Gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalRelief.py" line="117"/>
+        <location filename="../../SheetMetalRelief.py" line="122"/>
         <source>Relief Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="273"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="275"/>
         <source>Sketch on Sheetmetal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlangeParameters</name>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="20"/>
+        <source>Flange Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="30"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="41"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="79"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="84"/>
+        <source>SubElement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="92"/>
+        <source>Bend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="98"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="106"/>
+        <source>Material Outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="111"/>
+        <source>Material Inside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="116"/>
+        <source>Thickness Outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="121"/>
+        <location filename="../panels/FlangeParameters.ui" line="129"/>
+        <source>Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="146"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="169"/>
+        <location filename="../panels/FlangeParameters.ui" line="618"/>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="192"/>
+        <source>Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="214"/>
+        <source>Length mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="222"/>
+        <source>Leg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="227"/>
+        <source>Outer Sharp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="232"/>
+        <source>Inner Sharp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="237"/>
+        <source>Tangential</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="249"/>
+        <source>Unfold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="256"/>
+        <source>Reversed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="282"/>
+        <source>Offsets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="294"/>
+        <source>Side Offsets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="300"/>
+        <source>Gap A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="317"/>
+        <source>Gap B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="334"/>
+        <source>Extend A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="351"/>
+        <source>Extend B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="368"/>
+        <source>Relief Cuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="374"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="387"/>
+        <source>Depth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="404"/>
+        <source>mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="419"/>
+        <source>Rectangle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="432"/>
+        <source>Round</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="474"/>
+        <source>Miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="480"/>
+        <source>Auto Miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="493"/>
+        <source>Auto Miter Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="499"/>
+        <source>Minimum Gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="516"/>
+        <source>Max Extend Distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="536"/>
+        <source>Manual Miter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="568"/>
+        <source>Angle 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="575"/>
+        <source>Angle 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="599"/>
+        <source>Perforation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="605"/>
+        <source>Perforate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="612"/>
+        <source>Perforation Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="635"/>
+        <source>Initial Cut Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="652"/>
+        <source>Max Cut Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/FlangeParameters.ui" line="669"/>
+        <source>Max Tab Length</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -405,15 +649,15 @@
 <context>
     <name>Logger</name>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="419"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="412"/>
         <source>Base shape edit mode: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="39"/>
-        <location filename="../../SheetMetalFoldCmd.py" line="40"/>
-        <location filename="../../SheetMetalFormingCmd.py" line="40"/>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="52"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="40"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="41"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="45"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="57"/>
         <source>Shape is not a real 3D-object or to small for a metal-sheet!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -466,12 +710,12 @@
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../SheetMetalTools.py" line="24"/>
+        <location filename="../../SheetMetalTools.py" line="55"/>
         <source>Error in macro MessageBox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalTools.py" line="57"/>
+        <location filename="../../SheetMetalTools.py" line="423"/>
         <source>The selected geometry does not belong to the active Body.
 Please make the container of this item active by
 double clicking on it.</source>
@@ -503,74 +747,103 @@ If the opposite face also fails then switch Refine to false on feature </source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../SheetMetalBend.py" line="152"/>
-        <location filename="../../SheetMetalBend.py" line="159"/>
-        <location filename="../../SheetMetalCmd.py" line="1795"/>
-        <location filename="../../SheetMetalCmd.py" line="1805"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="336"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="343"/>
-        <location filename="../../SheetMetalFormingCmd.py" line="193"/>
-        <location filename="../../SheetMetalFormingCmd.py" line="200"/>
-        <location filename="../../SheetMetalJunction.py" line="113"/>
-        <location filename="../../SheetMetalJunction.py" line="120"/>
-        <location filename="../../SheetMetalRelief.py" line="162"/>
-        <location filename="../../SheetMetalRelief.py" line="169"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="237"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="245"/>
+        <location filename="../../SheetMetalTools.py" line="326"/>
         <source>Edit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SMAddJunctionTaskPanel</name>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="14"/>
+        <source>Add Junction Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="25"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="63"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="68"/>
+        <source>SubElement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="76"/>
+        <source>Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="95"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/AddJunctionPanel.ui" line="115"/>
+        <source>Refine</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SMBaseShape</name>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="126"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="127"/>
         <source>Thickness of sheetmetal</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="132"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="133"/>
         <source>Bend Radius</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="138"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="139"/>
         <source>Shape width</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="144"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="145"/>
         <source>Shape length</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="150"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="151"/>
         <source>Shape height</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="156"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="157"/>
         <source>Width of top flange</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="162"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="163"/>
         <source>Base shape type</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="169"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="170"/>
         <source>Location of part origin</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="178"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="179"/>
         <source>Extend sides and flange to close all gaps</source>
         <comment>Property</comment>
         <translation type="unfinished"></translation>
@@ -665,7 +938,7 @@ If the opposite face also fails then switch Refine to false on feature </source>
     </message>
     <message>
         <location filename="../panels/BaseShapeOptions.ui" line="386"/>
-        <source>height of base shape</source>
+        <source>Height of base shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -705,44 +978,77 @@ If the opposite face also fails then switch Refine to false on feature </source>
     </message>
 </context>
 <context>
+    <name>SMBendCornerTaskPanel</name>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="14"/>
+        <source>Bend sharp corner Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="25"/>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="63"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="68"/>
+        <source>SubElement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="76"/>
+        <source>Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="95"/>
+        <source>Radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/BendCornerPanel.ui" line="115"/>
+        <source>Refine</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>SMBendOnLineTaskPanel</name>
     <message>
         <location filename="../panels/BendOnLinePanel.ui" line="14"/>
-        <source>Generate Sheet Metal base shape</source>
+        <source>Fold on sketch line parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="32"/>
-        <source>Bend Line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="39"/>
+        <location filename="../panels/BendOnLinePanel.ui" line="43"/>
         <source>Base Object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="46"/>
-        <source>Feature Name</source>
+        <location filename="../panels/BendOnLinePanel.ui" line="53"/>
+        <source>Bend Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="64"/>
+        <location filename="../panels/BendOnLinePanel.ui" line="68"/>
         <source>Flip Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="71"/>
+        <location filename="../panels/BendOnLinePanel.ui" line="75"/>
         <source>Unbend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="83"/>
+        <location filename="../panels/BendOnLinePanel.ui" line="87"/>
         <source>Bend Radius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/BendOnLinePanel.ui" line="96"/>
+        <location filename="../panels/BendOnLinePanel.ui" line="100"/>
         <source>Bend Angle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -755,33 +1061,75 @@ If the opposite face also fails then switch Refine to false on feature </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="29"/>
-        <source>Relief Size</source>
+        <location filename="../panels/CornerReliefPanel.ui" line="25"/>
+        <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="70"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="69"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="74"/>
+        <source>SubElement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="88"/>
         <source>Relief Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="80"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="96"/>
         <source>Circular</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="90"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="109"/>
         <source>Square</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="97"/>
-        <source>Scaling</source>
+        <location filename="../panels/CornerReliefPanel.ui" line="119"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="152"/>
+        <source>Sketch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/CornerReliefPanel.ui" line="104"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="171"/>
+        <source>X Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="194"/>
+        <source>Y Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="223"/>
+        <location filename="../panels/CornerReliefPanel.ui" line="280"/>
+        <source>Relief Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="231"/>
+        <source>Absolute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="241"/>
+        <source>Relative</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="321"/>
         <source>Scale Factor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/CornerReliefPanel.ui" line="343"/>
+        <source>K Factor</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -827,37 +1175,140 @@ If the opposite face also fails then switch Refine to false on feature </source>
     <name>SMExtendTaskPanel</name>
     <message>
         <location filename="../panels/ExtendTaskPanel.ui" line="14"/>
-        <source>Generate Sheet Metal base shape</source>
+        <source>Extend Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="32"/>
-        <source>Feature Name</source>
+        <location filename="../panels/ExtendTaskPanel.ui" line="25"/>
+        <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="39"/>
-        <source>Base Element</source>
+        <location filename="../panels/ExtendTaskPanel.ui" line="63"/>
+        <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="46"/>
+        <location filename="../panels/ExtendTaskPanel.ui" line="68"/>
+        <source>SubElement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtendTaskPanel.ui" line="76"/>
+        <source>Extend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtendTaskPanel.ui" line="112"/>
         <source>Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="62"/>
-        <source>Flange Side Offset</source>
+        <location filename="../panels/ExtendTaskPanel.ui" line="119"/>
+        <source>Offset A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="74"/>
-        <source>SideA</source>
+        <location filename="../panels/ExtendTaskPanel.ui" line="132"/>
+        <source>Offset B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/ExtendTaskPanel.ui" line="81"/>
-        <source>SideB</source>
+        <location filename="../panels/ExtendTaskPanel.ui" line="146"/>
+        <source>Refine</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SMExtrudedCutoutTaskPanel</name>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="20"/>
+        <source>Extruded Cutout Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="32"/>
+        <source>Base Features</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="62"/>
+        <source>Sketch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="72"/>
+        <source>Face</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="94"/>
+        <source>Cutout Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="102"/>
+        <source>Inside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="112"/>
+        <source>Outside</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="126"/>
+        <source>Cutout Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="140"/>
+        <source>Two Dimensions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="145"/>
+        <source>Symmetric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="150"/>
+        <source>Through All Both Sides</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="155"/>
+        <source>Through All Side A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="160"/>
+        <source>Through All Side B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="197"/>
+        <source>Side A Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="238"/>
+        <source>Side B Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="258"/>
+        <source>Improve Cutout (Slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="286"/>
+        <source>Improve Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../panels/ExtrudedCutoutPanel.ui" line="315"/>
+        <source>Refine</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -930,121 +1381,40 @@ If the opposite face also fails then switch Refine to false on feature </source>
     </message>
 </context>
 <context>
-    <name>SMFlangeTaskPanel</name>
+    <name>SMSolidCornerReliefTaskPanel</name>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="14"/>
-        <source>Flange Parameters</source>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="14"/>
+        <source>Add Corner Relief on Solid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="25"/>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="25"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="63"/>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="63"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="68"/>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="68"/>
         <source>SubElement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="76"/>
-        <source>Bend</source>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="76"/>
+        <source>Extend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="82"/>
-        <source>Type</source>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="95"/>
+        <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../panels/FlangeParameters.ui" line="90"/>
-        <source>Material Outside</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="95"/>
-        <source>Material Inside</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="100"/>
-        <source>Thickness Outside</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="105"/>
-        <location filename="../panels/FlangeParameters.ui" line="113"/>
-        <source>Offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="130"/>
-        <source>Radius</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="153"/>
-        <source>Angle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="176"/>
-        <source>Length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="198"/>
-        <source>Length mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="206"/>
-        <source>Leg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="211"/>
-        <source>Outer Sharp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="216"/>
-        <source>Inner Sharp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="221"/>
-        <source>Tangential</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="233"/>
-        <source>Unfold</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="240"/>
-        <source>Reversed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="252"/>
-        <source>Side Offsets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="258"/>
-        <source>Side A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../panels/FlangeParameters.ui" line="272"/>
-        <source>Side B</source>
+        <location filename="../panels/SolidCornerReliefPanel.ui" line="115"/>
+        <source>Refine</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1210,87 +1580,117 @@ If the opposite face also fails then switch Refine to false on feature </source>
 <context>
     <name>SheetMetal</name>
     <message>
-        <location filename="../../InitGui.py" line="54"/>
-        <location filename="../../InitGui.py" line="96"/>
-        <location filename="../../InitGui.py" line="117"/>
+        <location filename="../../ExtrudedCutout.py" line="61"/>
+        <source>Selected face</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ExtrudedCutout.py" line="70"/>
+        <source>Refine the geometry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ExtrudedCutout.py" line="79"/>
+        <source>Level of cut improvement quality. More than 10 can take a very long time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ExtrudedCutout.py" line="87"/>
+        <source>Improve cut geometry if it enters the cutting zone. Only select true if the cut needs fix, &apos;cause it can be slow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ExtrudedCutout.py" line="395"/>
+        <source>Side A Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../ExtrudedCutout.py" line="396"/>
+        <source>Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../InitGui.py" line="55"/>
+        <location filename="../../InitGui.py" line="99"/>
+        <location filename="../../InitGui.py" line="120"/>
         <source>Sheet Metal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../InitGui.py" line="58"/>
+        <location filename="../../InitGui.py" line="59"/>
         <source>Sheet Metal workbench allows for designing and unfolding sheet metal parts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../InitGui.py" line="99"/>
+        <location filename="../../InitGui.py" line="102"/>
         <source>&amp;Sheet Metal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseCmd.py" line="241"/>
+        <location filename="../../SheetMetalBaseCmd.py" line="242"/>
         <source>Make Base Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseCmd.py" line="248"/>
+        <location filename="../../SheetMetalBaseCmd.py" line="249"/>
         <source>Create a sheetmetal wall from a sketch
-1. Select a Skech to create bends with walls.
+1. Select a Sketch to create bends with walls.
 2. Use Property editor to modify other parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="454"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="446"/>
         <source>Add base shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBaseShapeCmd.py" line="459"/>
+        <location filename="../../SheetMetalBaseShapeCmd.py" line="451"/>
         <source>Add basic sheet metal object.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBend.py" line="374"/>
+        <location filename="../../SheetMetalBend.py" line="200"/>
         <source>Make Bend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalBend.py" line="380"/>
+        <location filename="../../SheetMetalBend.py" line="207"/>
         <source>Create Bend where two walls come together on solids
 1. Select edge(s) to create bend on corner edge(s).
 2. Use Property editor to modify parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="2045"/>
+        <location filename="../../SheetMetalCmd.py" line="1819"/>
         <source>Make Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCmd.py" line="2052"/>
+        <location filename="../../SheetMetalCmd.py" line="1826"/>
         <source>Extends one or more face, connected by a bend on existing sheet metal.
 1. Select edges or thickness side faces to create bends with walls.
 2. Use Property editor to modify other parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="619"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="603"/>
         <source>Add Corner Relief</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalCornerReliefCmd.py" line="626"/>
+        <location filename="../../SheetMetalCornerReliefCmd.py" line="610"/>
         <source>Corner Relief to metal sheet corner.
 1. Select 2 Edges (on flat face that shared with bend faces) to create Relief on sheetmetal.
 2. Use Property editor to modify default parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="561"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="426"/>
         <source>Extend Face</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalExtendCmd.py" line="568"/>
+        <location filename="../../SheetMetalExtendCmd.py" line="434"/>
         <source>Extends one or more face, on existing sheet metal.
 1. Select edges or thickness side faces to create walls.
 2. Select a sketch in property editor to create tabs. 
@@ -1298,12 +1698,12 @@ If the opposite face also fails then switch Refine to false on feature </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="437"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="377"/>
         <source>Fold a Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFoldCmd.py" line="446"/>
+        <location filename="../../SheetMetalFoldCmd.py" line="386"/>
         <source>Fold a wall of metal sheet
 1. Select a flat face on sheet metal and
 2. Select a bend line (sketch) on same face (ends of sketch bend lines must extend beyond edges of face) to create sheetmetal fold.
@@ -1311,12 +1711,12 @@ If the opposite face also fails then switch Refine to false on feature </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="459"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="509"/>
         <source>Make Forming in Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalFormingCmd.py" line="467"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="517"/>
         <source>Make a forming using tool in metal sheet
 1. Select a flat face on sheet metal and
 2. Select face(s) on forming tool Shape to create Formed sheetmetal.
@@ -1325,24 +1725,24 @@ If the opposite face also fails then switch Refine to false on feature </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalJunction.py" line="334"/>
+        <location filename="../../SheetMetalJunction.py" line="161"/>
         <source>Make Junction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalJunction.py" line="340"/>
+        <location filename="../../SheetMetalJunction.py" line="167"/>
         <source>Create a rip where two walls come together on solids.
 1. Select edge(s) to create rip on corner edge(s).
 2. Use Property editor to modify parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalRelief.py" line="384"/>
+        <location filename="../../SheetMetalRelief.py" line="201"/>
         <source>Make Relief</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SheetMetalRelief.py" line="390"/>
+        <location filename="../../SheetMetalRelief.py" line="207"/>
         <source>Modify an Individual solid corner to create Relief.
 1. Select Vertex(es) to create Relief on Solid corner Vertex(es).
 2. Use Property editor to modify default parameters</source>
@@ -1373,13 +1773,14 @@ If the opposite face also fails then switch Refine to false on feature </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="417"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="419"/>
         <source>Sketch On Sheet metal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../SketchOnSheetMetalCmd.py" line="425"/>
+        <location filename="../../SketchOnSheetMetalCmd.py" line="428"/>
         <source>Extruded cut from Sketch On Sheet metal faces
+NOTE: Deprecated. Use Extruded Cutout function
 1. Select a flat face on sheet metal and
 2. Select a sketch on same face to create sheetmetal extruded cut.
 3. Use Property editor to modify other parameters</source>
@@ -1389,11 +1790,8 @@ If the opposite face also fails then switch Refine to false on feature </source>
 <context>
     <name>draft</name>
     <message>
-        <location filename="../../SheetMetalBend.py" line="366"/>
-        <location filename="../../SheetMetalExtendCmd.py" line="554"/>
-        <location filename="../../SheetMetalFormingCmd.py" line="451"/>
-        <location filename="../../SheetMetalJunction.py" line="326"/>
-        <location filename="../../SheetMetalRelief.py" line="376"/>
+        <location filename="../../SheetMetalFormingCmd.py" line="502"/>
+        <location filename="../../SheetMetalJunction.py" line="154"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Resources/translations/update_translation.sh
+++ b/Resources/translations/update_translation.sh
@@ -79,16 +79,37 @@ update_locale() {
 	fi
 }
 
+normalize_crowdin_files() {
+	# Rename files which locales are different on FreeCAD and delete not supported locales
+	crowdin_fixes=(af-ZA ar-SA be-BY bg-BG ca-ES cs-CZ da-DK de-DE el-GR eu-ES fi-FI
+		fil-PH fr-FR gl-ES hr-HR hu-HU it-IT ja-JP ka-GE kab-KAB ko-KR lt-LT nl-NL
+		no-NO pl-PL ro-RO ru-RU sk-SK sl-SI sr-SP tr-TR uk-UA vi-VN)
+
+	crowdin_deletes=(az-AZ bn-BD br-FR bs-BA en en-GB en-US eo-UY es-CO es-VE et-EE fa-IR he-IL
+		hi-IN hy-AM id-ID kaa lv-LV mk-MK ms-MY sat-IN si-LK ta-IN te-IN th-TH ur-PK xav yo-NG)
+
+	for pattern in "${crowdin_fixes[@]}"; do
+		find . -type f -name "*_${pattern}\.*" | while read -r file; do
+			mv -v "$file" "${file//-*./.}"
+		done
+	done
+
+	for pattern in "${crowdin_deletes[@]}"; do
+		find . -type f -name "*_${pattern}\.*" -delete
+	done
+}
+
 help() {
 	echo -e "\nDescription:"
 	echo -e "\tCreate, update and release translation files."
 	echo -e "\nUsage:"
 	echo -e "\t./update_translation.sh [-R] [-U] [-r <locale>] [-u <locale>]"
 	echo -e "\nFlags:"
-	echo -e "  -R\n\tRelease all locales"
-	echo -e "  -U\n\tUpdate main translation file (locale agnostic)"
+	echo -e "  -R\n\tRelease all translations (qm files)"
+	echo -e "  -U\n\tUpdate all translations (ts files)"
 	echo -e "  -r <locale>\n\tRelease the specified locale"
 	echo -e "  -u <locale>\n\tUpdate strings for the specified locale"
+	echo -e "  -N\n\tNormalize CrowdIn filenames"
 }
 
 # Main function ------------------------------------------------------------------------------------
@@ -99,19 +120,24 @@ LRELEASE=/usr/lib/qt6/bin/lrelease # from Qt6
 # LRELEASE=lrelease                 # from Qt5
 WB="SheetMetal"
 
-# Enforce underscore on locales
-sed -i '3s/-/_/' ${WB}*.ts
+sed -i '3s/-/_/' ${WB}*.ts               # Enforce underscore on locales
+sed -i '3s/\"en\"/\"en_US\"/g' ${WB}*.ts # Use en_US
 
 if [ $# -eq 1 ]; then
 	if [ "$1" == "-R" ]; then
 		find . -type f -name '*_*.ts' | while IFS= read -r file; do
 			# Release all locales
-			$LRELEASE "$file"
+			$LRELEASE -nounfinished "$file"
 			echo
 		done
 	elif [ "$1" == "-U" ]; then
-		# Update main file (agnostic)
-		update_locale
+		for locale in "${supported_locales[@]}"; do
+			update_locale "$locale"
+		done
+	elif [ "$1" == "-u" ]; then
+		update_locale # Update main file (agnostic)
+	elif [ "$1" == "-N" ]; then
+		normalize_crowdin_files
 	else
 		help
 	fi
@@ -120,7 +146,7 @@ elif [ $# -eq 2 ]; then
 	if is_locale_supported "$LOCALE"; then
 		if [ "$1" == "-r" ]; then
 			# Release locale (creation of *.qm file from *.ts file)
-			$LRELEASE "${WB}_${LOCALE,,}.ts"
+			$LRELEASE -nounfinished "${WB}_${LOCALE,,}.ts"
 		elif [ "$1" == "-u" ]; then
 			# Update main & locale files
 			update_locale

--- a/SheetMetalBaseCmd.py
+++ b/SheetMetalBaseCmd.py
@@ -118,7 +118,7 @@ class SMBaseBend:
         obj.addProperty(
             "App::PropertyLength", "thickness", "Parameters", _tip_
         ).thickness = 1.0
-        _tip_ = translate("App::Property", "Relief Type")
+        _tip_ = translate("App::Property", "Bend Plane")
         obj.addProperty(
             "App::PropertyEnumeration", "BendSide", "Parameters", _tip_
         ).BendSide = ["Outside", "Inside", "Middle"]
@@ -244,7 +244,7 @@ if SheetMetalTools.isGuiLoaded():
                 "ToolTip": translate(
                     "SheetMetal",
                     "Create a sheetmetal wall from a sketch\n"
-                    "1. Select a Skech to create bends with walls.\n"
+                    "1. Select a Sketch to create bends with walls.\n"
                     "2. Use Property editor to modify other parameters",
                 ),
             }

--- a/SheetMetalFormingCmd.py
+++ b/SheetMetalFormingCmd.py
@@ -162,7 +162,9 @@ class SMBendWall:
         obj.addProperty("App::PropertyLinkSub", "toolObject", "Parameters",
                         _tip_).toolObject = (seltool, seltool_items)
         _tip_ = FreeCAD.Qt.translate(
-            "App::Property", "Point Sketch on Sheetmetal")
+            "App::Property",
+            "Sketch containing circle's points to multiply and pattern the embossed feature",
+        )
         obj.addProperty("App::PropertyLink", "Sketch", "Parameters1", _tip_)
         obj.Proxy = self
 


### PR DESCRIPTION
There we some issues found on CrowdIn.

---

After running
```shell
 awk 'BEGIN { RS="</source>" } /<source>/ { gsub(/.*<source>/, ""); print }' SheetMetal.ts | aspell --lang=en list | sort | uniq
```
only this strings appear as typos. Some are becaus eof Qt so no way to change it but should we rename/capitalize those sheetmetal strings?

- DXF
- MessageBox
- SVG
- SheetMetal
- Sheetmetal
- SubElement
- UX
- apos
- discretizing
- href
- li
- lt
- ol
- readonly
- sheetmetal


Since 1.0 is close I think it's good idea to check if strings are appropiate/understandable, maybeask users on the forum?