### PR TITLE
Legacy compatibility (< 0.21) and object visibility (UnfoldUnattended)

### DIFF
--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -550,6 +550,7 @@ if SheetMetalTools.isGuiLoaded():
             SMUnfoldViewProvider(newObj.ViewObject)
             SheetMetalTools.smAddNewObject(selobj, newObj, activeBody)
             smUnfoldExportSketches(newObj, False)           
+            selobj.Visibility = True
             return
 
         def IsActive(self):

--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -3129,6 +3129,9 @@ def generateSketch(edges, name, color, existingSketches = None):
 
     if FreeCAD.GuiUp:
         rgb_color = tuple(int(color[i : i + 2], 16) for i in (1, 3, 5))
+        v = FreeCAD.Version()
+        if v[0] == '0' and int(v[1]) < 21:
+            rgb_color = tuple(i / 255 for i in rgb_color)
         sk.ViewObject.LineColor = rgb_color
         sk.ViewObject.PointColor = rgb_color
 


### PR DESCRIPTION
Hi @shaise.

A small addition for the ability to use older versions of FreeCAD. My previous change got lost :)

SMUnfoldUnattended: I suggest not hiding the highlighted object in this case #426.
I'm just giving him back visibility, maybe it's not very elegant...