### PR TITLE
Removing export (UnfoldUnattended) and sketches recompute

### DIFF
--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -261,6 +261,7 @@ if SheetMetalTools.isGuiLoaded():
             for itemName in self.Object.UnfoldSketches:
                 item = self.Object.Document.getObject(itemName)
                 if item is not None:
+                    item.recompute(True)
                     objs.append(item)
             return objs
 
@@ -549,7 +550,6 @@ if SheetMetalTools.isGuiLoaded():
             SMUnfold(newObj, selobj, sel.SubElementNames)
             SMUnfoldViewProvider(newObj.ViewObject)
             SheetMetalTools.smAddNewObject(selobj, newObj, activeBody)
-            smUnfoldExportSketches(newObj, False)           
             selobj.Visibility = True
             return
 


### PR DESCRIPTION
Hi,

**SMUnfoldUnattended** exported the drawing - this is clearly unnecessary.
I also added recalculation of created sketches so that they do not affect the document status.