### PR TITLE
Improve bend offset calculations when angle isn't 90deg.

### DIFF
--- a/Resources/panels/FlangeParameters.ui
+++ b/Resources/panels/FlangeParameters.ui
@@ -1408,6 +1408,26 @@ min-width: 28px;</string>
                    </iconset>
                   </property>
                  </item>
+                 <item>
+                  <property name="text">
+                   <string>Material Inside (90° legacy)</string>
+                  </property>
+                  <property name="icon">
+                   <iconset>
+                    <normalon>Icons:SheetMetal_WallPosMatIns.svg</normalon>
+                   </iconset>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Thickness Outside (legacy)</string>
+                  </property>
+                  <property name="icon">
+                   <iconset>
+                    <normalon>Icons:SheetMetal_WallPosThkOut.svg</normalon>
+                   </iconset>
+                  </property>
+                 </item>
                 </widget>
                </item>
               </layout>

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1263,10 +1263,16 @@ def smBend(
     if BendType == "Material Outside":
         offset = 0.0
         inside = False
-    elif BendType == "Material Inside":
+    elif BendType == "Material Inside": # legacy mode for backwards compatibility
+        offset = -(thk + bendR)
+        inside = True
+    elif BendType == "Thickness Outside": # legacy mode for backwards compatibility
+        offset = -bendR
+        inside = True
+    elif BendType == "Material Inside V2":
         offset = -(thk + bendR) * abs(math.tan(math.radians(bendA * 0.5)))
         inside = True
-    elif BendType == "Thickness Outside":
+    elif BendType == "Thickness Outside V2":
         offset = -bendR * abs(math.tan(math.radians(bendA * 0.5)))
         inside = True
     elif BendType == "Offset":
@@ -1781,7 +1787,9 @@ class SMBendWall:
             obj,
             "BendType",
             translate("App::Property", "Bend Type"),
-            ["Material Outside", "Material Inside", "Thickness Outside", "Offset"],
+            ["Material Outside", "Material Inside V2", "Thickness Outside V2", "Offset",
+             # legacy modes
+             "Material Inside", "Thickness Outside"],
         )
         SheetMetalTools.smAddEnumProperty(
             obj,

--- a/SheetMetalCmd.py
+++ b/SheetMetalCmd.py
@@ -1264,10 +1264,10 @@ def smBend(
         offset = 0.0
         inside = False
     elif BendType == "Material Inside":
-        offset = -(thk + bendR)
+        offset = -(thk + bendR) * abs(math.tan(math.radians(bendA * 0.5)))
         inside = True
     elif BendType == "Thickness Outside":
-        offset = -bendR
+        offset = -bendR * abs(math.tan(math.radians(bendA * 0.5)))
         inside = True
     elif BendType == "Offset":
         if offset < 0.0:
@@ -1278,14 +1278,14 @@ def smBend(
     if LengthSpec == "Leg":
         pass
     elif LengthSpec == "Tangential":
-        if bendA >= 90.0:
+        if bendA >= 90.0 or bendA <= -90.0:
             extLen -= thk + bendR
         else:
-            extLen -= (bendR + thk) / math.tan(math.radians(90.0 - bendA / 2))
+            extLen -= (bendR + thk) / abs(math.tan(math.radians(90.0 - bendA / 2)))
     elif LengthSpec == "Inner Sharp":
-        extLen -= (bendR) / math.tan(math.radians(90.0 - bendA / 2))
+        extLen -= (bendR) / abs(math.tan(math.radians(90.0 - bendA / 2)))
     elif LengthSpec == "Outer Sharp":
-        extLen -= (bendR + thk) / math.tan(math.radians(90.0 - bendA / 2))
+        extLen -= (bendR + thk) / abs(math.tan(math.radians(90.0 - bendA / 2)))
 
     nogaptrimedgelist = []
     if not (sketches):


### PR DESCRIPTION
TODO: will prepare test project and screenshots tomorrow.

Previously when doing bend using "Make wall" command "Material Inside" and "Material Outside" modes didn't take into account the angle.

Test plan:

- Using Outer sharp or Inner sharp modes
    * Material inside, 90 > angle > 0
    * Material inside, angle > 90
    * Material inside, -90 < angle < 0
    * Material inside, angle < -90
    * Material outside, 90 > angle > 0
    * Material outside, angle > 90
    * Material outside, -90 < angle < 0
    * Material outside, angle < -90
    
 In each of the cases above changing radius should not affect endpoint
  
 - Using inner sharp mode change angle from -145 to 145
 - Using outer  sharp mode change angle from -145 to 145
 - Using tangential mode change angle from -145 to 145
 
 During the 3 cases described above the shape should change smoothly, negative angles should look the same as positive angle reversed.
 