### PR TITLE
handle invalid elements correctly

### DIFF
--- a/SheetMetalNewUnfolder.py
+++ b/SheetMetalNewUnfolder.py
@@ -1303,7 +1303,8 @@ def getUnfold(
 ) -> tuple[Part.Face, Part.Shape, Part.Compound, Vector]:
     object_placement = solid.Placement.toMatrix()
     shp = solid.Shape.transformed(object_placement.inverse())
-    root_face_index = int(facename[4:]) - 1
+    subshape = shp.getElement(facename)
+    root_face_index = shp.findSubShape(subshape)[1] - 1
     sketch_lines, bend_lines = unfold(shp, root_face_index, bac)
     sketch_align_transform = SketchExtraction.move_to_origin(
         Part.makeCompound(sketch_lines), shp.Faces[root_face_index]


### PR DESCRIPTION
improves https://forum.freecad.org/viewtopic.php?p=807080#p807996

before:
```python
...
<class 'ValueError'>: invalid literal for int() with base 10: 'e81'
20:36:39  Sheet_Unfold: invalid literal for int() with base 10: 'e81'
```

after:
```python
...
<class 'ValueError'>: Invalid shape name ?Face81
15:02:43  Sheet_Unfold: Invalid shape name ?Face81
```