### PR TITLE
Handle the removal of the Drawing module from FreeCAD 1.1dev

### DIFF
--- a/SheetMetalUnfolder.py
+++ b/SheetMetalUnfolder.py
@@ -119,7 +119,12 @@ import SheetMetalTools
 try:
     from TechDraw import projectEx
 except ImportError:
-    from Drawing import projectEx
+    try:
+        from Drawing import projectEx
+    except ImportError:
+        FreeCAD.Console.PrintWarning(
+            "This version of FreeCAD cannot create a projected sketch of the unfolded model\n"
+        )
 
 from lookup import get_val_from_range
 


### PR DESCRIPTION
Following the removal of the Drawing module from FreeCAD `main` a report has been raised in https://forum.freecad.org/viewtopic.php?p=828172#p828172 
This PR stops the error but still allows for those older versions to still function.

Tested using:

```
OS: Linux Mint 22.1 (X-Cinnamon/cinnamon/xcb)
Architecture: x86_64
Version: 1.1.0dev.41736 (Git) AppImage
Build date: 2025/05/19 10:15:51
Build type: Release
Branch: main
Hash: 76ce8ccfd5b52e520c052d2193d7a244e83d4cb6
Python 3.11.12, Qt 6.8.3, Coin 4.0.3, Vtk 9.3.1, boost 1_86, Eigen3 3.4.0, PySide 6.8.3
shiboken 6.8.3, xerces-c 3.2.5, IfcOpenShell 0.8.2, OCC 7.8.1
Locale: English/United Kingdom (en_GB)
Stylesheet/Theme/QtStyle: FreeCAD Dark.qss/FreeCAD Dark/
Logical DPI/Physical DPI/Pixel Ratio: 96/93.1131/1
Installed mods: 
  * FreeCAD-Ribbon 1.8.1.2 (Disabled)
  * btl 0.9.9
  * FreeCAD-themes 2025.1.7
  * Silk 0.1.6
  * sheetmetal 0.7.22
  * Behave-Dark-Colors 0.1.1
  * CfdOF 1.30.3
  * ChangeAppFont
  * Quetzal 1.5.6
  * fasteners 0.5.38
  * freecad.gears 1.3.0
  * Curves 0.6.61
  * OpenGlider-develop
  * QetWireManager
  * Assembly4 0.50.18
  * A2plus 0.4.68
  * ThreadProfile 1.94.0
```

```
OS: Linux Mint 22.1 (X-Cinnamon/cinnamon/xcb)
Architecture: x86_64
Version: 1.0.1.39286 (Git)
Build type: Release
Branch: releases/FreeCAD-1-0
Hash: ba50b8ce7923095016776f47f59a5bb1918f7d0e
Python 3.12.3, Qt 5.15.13, Coin 4.0.3, Vtk 9.1.0, OCC 7.8.2.dev
Locale: English/United Kingdom (en_GB)
Stylesheet/Theme/QtStyle: Behave-dark.qss/Behave-dark/Qt default
Installed mods: 
  * FreeCAD-Ribbon 1.8.1.2 (Disabled)
  * btl 0.9.9
  * FreeCAD-themes 2025.1.7
  * Silk 0.1.6
  * sheetmetal 0.7.22
  * Behave-Dark-Colors 0.1.1
  * CfdOF 1.30.3
  * ChangeAppFont
  * Quetzal 1.5.6
  * fasteners 0.5.38
  * freecad.gears 1.3.0
  * Curves 0.6.61
  * OpenGlider-develop
  * QetWireManager
  * Assembly4 0.50.18
  * A2plus 0.4.68
  * ThreadProfile 1.94.0
```

```
OS: Linux Mint 22.1 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.21.3.33893 (Git)
Build type: Release
Branch: main
Hash: 7403afe4d4168a9a270fe207696a08db8aaccc3d
Python 3.12.3, Qt 5.15.13, Coin 4.0.2, Vtk 9.1.0, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
Installed mods: 
  * FreeCAD-Ribbon 1.8.1.2
  * btl 0.9.9
  * FreeCAD-themes 2025.1.7
  * Silk 0.1.6
  * sheetmetal 0.7.22
  * Behave-Dark-Colors 0.1.1
  * CfdOF 1.30.3
  * ChangeAppFont
  * Quetzal 1.5.6
  * fasteners 0.5.38
  * freecad.gears 1.3.0
  * Curves 0.6.61
  * OpenGlider-develop
  * QetWireManager
  * Assembly4 0.50.18
  * A2plus 0.4.68
  * ThreadProfile 1.94.0
```

