### PR TITLE
Fix assign color for lines in UnfoldTaskPanel

### DIFF
--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -268,8 +268,8 @@ class SMUnfold:
                 obj.UnfoldSketches,
                 obj.SeparateSketchLayers, 
                 obj.Proxy.SketchColor,
-                bendSketchColor=obj.Proxy.InternalColor,
-                internalSketchColor=obj.Proxy.BendLineColor,
+                bendSketchColor=obj.Proxy.BendLineColor,
+                internalSketchColor=obj.Proxy.InternalColor,
             )
         return shape, sketches
 


### PR DESCRIPTION
Fix assign color for Internal and Fold lines. A bug was caused that a color selected in UnfoldTaskPanel for Bend lines was assigned for Internal lines and vice versa.

![fix_color_lines](https://github.com/user-attachments/assets/2ca33089-c1c7-4a6a-bbc6-e48f953e8f47)
