### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ SheetMetal WB can be installed via the [Addon Manager](https://github.com/FreeCA
                       - Update translations by [@hasecilu][hasecilu].  
                       - Fix python compatibility by [@Syres916][Syres916].  
                       - Extruded cutout fixes by [@sheetmetalman][sheetmetalman].  
-                      - Fix round relief apect ratio limitations.  
+                      - Fix round relief aspect ratio limitations.  
 * V0.6.00 03 Dec 2024:  Code refactoring, Remove duplication, Add GUI to most functions.  
 * V0.5.10 25 Nov 2024:  Extruded Cutout: add improvements and fixes by [@sheetmetalman][sheetmetalman].  
                       - Update translations from CrowdIn by [@hasecilu][hasecilu].  

--- a/Resources/translations/README.md
+++ b/Resources/translations/README.md
@@ -12,7 +12,7 @@ then find your language, look for the **Sheet Metal** project and do the transla
 ## Maintainers
 
 > [!NOTE]
-> All commands **must** be run in `./Resorces/translations/` directory.
+> All commands **must** be run in `./Resources/translations/` directory.
 
 > [!WARNING]
 > If you want to update/release the files you need to have installed


### PR DESCRIPTION
Not sure why vscode auto-formatted `SheetMetalFormingCmd.py`
I only fixed `./SheetMetalFormingCmd.py:100: faild ==> failed`

@zokhasan Any idea what changed in the refactor (ef2d459) that would cause this ?
