### PR TITLE
Improve TaskPanels: Sync with select objs in 'Select' mode

### DIFF
--- a/SheetMetalTools.py
+++ b/SheetMetalTools.py
@@ -135,7 +135,8 @@ if isGuiLoaded():
                 the `FreeCADGui.Selection`.
 
             """
-            self.sync_selection()
+            _, obj_name, sub_name, _ = args
+            add_qtreewidget_item(self.widget, obj_name, sub_name)
 
         def clearSelection(self, *args):
             """Execute when clearing the selection.

--- a/SheetMetalTools.py
+++ b/SheetMetalTools.py
@@ -123,10 +123,7 @@ if isGuiLoaded():
             self.widget.clear()
 
             for obj in Gui.Selection.getCompleteSelection():
-                item = QtGui.QTreeWidgetItem(self.widget)
-                item.setIcon(0, QtGui.QIcon(":/icons/Tree_Part.svg"))
-                item.setText(0, obj.ObjectName)
-                item.setText(1, obj.SubElementNames[0])
+                add_qtreewidget_item(self.widget, obj.ObjectName, obj.SubElementNames[0])
 
             scrollbar.setValue(scrollbar_position)
 
@@ -333,6 +330,21 @@ if isGuiLoaded():
                     obj.Visibility = False
 
 
+    def add_qtreewidget_item(widget, obj_name, sub_name):
+        """Add an item to a QTreeWidget with presetting.
+
+        Args:
+            widget: The QTreeWidget to which the item will be added.
+            obj_name: Name of the object.
+            sub_name: Name of the sub-element.
+
+        """
+        item = QtGui.QTreeWidgetItem(widget)
+        item.setIcon(0, QtGui.QIcon(":/icons/Tree_Part.svg"))
+        item.setText(0, obj_name)
+        item.setText(1, sub_name)
+
+
     # Task panel helper code.
     def taskPopulateSelectionList(qwidget, baseObject):
         qwidget.clear()
@@ -342,11 +354,7 @@ if isGuiLoaded():
         if not isinstance(items, list):
             items = [items]
         for subf in items:
-            # FreeCAD.Console.PrintLog("item: " + subf + "\n")
-            item = QtGui.QTreeWidgetItem(qwidget)
-            item.setText(0, obj.Name)
-            item.setIcon(0, QtGui.QIcon(":/icons/Tree_Part.svg"))
-            item.setText(1, subf)
+            add_qtreewidget_item(qwidget, obj.Name, subf)
 
 
     def taskPopulateSelectionSingle(textbox, selObject):


### PR DESCRIPTION
Improve TaskPanels: Sync with selected objs in "SELECT" mode.

https://github.com/user-attachments/assets/b8274cf4-eb98-443f-bac0-c1043260e686


The change is already able to work, but I'm still going to check
if it's possible to remove other duplicating observer func and
classes in SheetMetalTools.py

I also would welcome to see feedback on how I connected this class in task panels.
In TaskPanels:
```python
class SomeTaskPanel:
    def __init__(self, obj):
        #...
        self.form.AddRemove.clicked.connect(self.select_clicked)

    def select_clicked(self):
        SheetMetalTools.SelectionObserver.manager(task_panel=self)
```
In the panel class when user click the `Select` button I call the `select_clicked` method in wich i send the `self` value as attribute.This is somewhat similar to the delegation approach, but with the self attribute being sent.
I'm comfused about sent "self" for an other class. But in the same time I like the ability to connect in 3 lines to any panel. What do you think about it?

-----------

In [SheetMetal v1.0 Milestones #412](https://github.com/shaise/FreeCAD_SheetMetal/issues/412) has the item "`Add option to delete edges from multi selections in the task panel`". How do you imagine it: like this or like this or how else?


<img width="650" height="405" alt="2" src="https://github.com/user-attachments/assets/367d6e5d-0c6e-44d1-b7e5-8b9bc6176049" />

