### PR TITLE
Support for folding marks and relief cuts on the laser

### DIFF
--- a/Resources/panels/UnfoldOptions.ui
+++ b/Resources/panels/UnfoldOptions.ui
@@ -294,6 +294,175 @@
        </layout>
       </item>
       <item>
+       <widget class="QWidget" name="groupBendCuts" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="margin">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_13">
+           <item>
+            <widget class="QCheckBox" name="chkBendCuts">
+             <property name="text">
+              <string>Generate bend relief cuts</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="Gui::ColorButton" name="cutColor">
+             <property name="color" stdset="0">
+              <color>
+               <red>0</red>
+               <green>192</green>
+               <blue>255</blue>
+              </color>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QWidget" name="groupBendCutsBody" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <property name="margin">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <item>
+               <widget class="QLabel" name="label_9">
+                <property name="text">
+                 <string>Relief shape</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="radioStraightCut">
+                <property name="text">
+                 <string>Straight</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">cutShapeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="radioSketchCut">
+                <property name="text">
+                 <string>From sketch</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">cutShapeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
+              <item>
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Max material distance (bridge)</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="Gui::QuantitySpinBox" name="maxMaterialDist">
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="unit" stdset="0">
+                 <string notr="true">mm</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_16">
+              <item>
+               <widget class="QLabel" name="label_11">
+                <property name="text">
+                 <string>Max cut distance</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="Gui::QuantitySpinBox" name="maxCutDist">
+                <property name="minimum">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="unit" stdset="0">
+                 <string notr="true">mm</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_17">
+              <item>
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>Edge offset</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="Gui::QuantitySpinBox" name="cutEdgeOffset">
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="unit" stdset="0">
+                 <string notr="true">mm</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QWidget" name="groupCutShape" native="true">
+              <layout class="QHBoxLayout" name="horizontalLayout_18">
+               <property name="margin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="pushCutSketch">
+                 <property name="text">
+                  <string>Pick sketch</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="txtCutSketch"/>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="groupExport" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_11">
          <property name="margin">
@@ -502,5 +671,6 @@
  <buttongroups>
   <buttongroup name="exportGroup"/>
   <buttongroup name="kFactorGroup"/>
+  <buttongroup name="cutShapeGroup"/>
  </buttongroups>
 </ui>

--- a/SheetMetalBendCuts.py
+++ b/SheetMetalBendCuts.py
@@ -37,8 +37,6 @@ the sheet metal feature tree - it only ever reads a straight edge and
 returns new, unrelated cut edges.
 """
 
-import math
-
 import FreeCAD
 import Part
 
@@ -131,10 +129,10 @@ def segment_bend_line(length, max_cut, max_material, edge_offset):
 ###################################################################################################
 
 def build_relief_cuts_for_bend(bend_info, max_cut, max_material, edge_offset,
-                                profile_wire=None):
+                                profile_points=None):
     """bend_info: object with a `.line` attribute (a straight Part.Edge),
        e.g. SheetMetalNewUnfolder.BendInfo or BareEdgeBendInfo.
-    profile_wire: optional normalized 2D Part.Wire (see
+    profile_points: optional normalized 2D point list (see
                   `normalize_profile_sketch`) or None for a plain
                   straight cut.
     Returns a Part.Compound of the *cut* geometry only (bridges are gaps,
@@ -158,10 +156,10 @@ def build_relief_cuts_for_bend(bend_info, max_cut, max_material, edge_offset,
             continue
         p1 = edge.valueAt(edge.FirstParameter + start)
         p2 = edge.valueAt(edge.FirstParameter + end)
-        if profile_wire is None:
+        if profile_points is None:
             cut_shapes.append(Part.makeLine(p1, p2))
         else:
-            placed = _place_profile_on_span(profile_wire, p1, p2)
+            placed = _place_profile_on_span(profile_points, p1, p2)
             if placed is not None:
                 cut_shapes.append(placed)
     if not cut_shapes:
@@ -170,7 +168,7 @@ def build_relief_cuts_for_bend(bend_info, max_cut, max_material, edge_offset,
 
 
 def build_relief_cuts(bend_infodata, max_cut, max_material, edge_offset,
-                       profile_wire=None):
+                       profile_points=None):
     """Build relief-cut geometry for a whole list of bends at once.
 
     Returns a tuple (cut_compound, fallback_edges):
@@ -186,7 +184,7 @@ def build_relief_cuts(bend_infodata, max_cut, max_material, edge_offset,
     fallback_edges = []
     for bend_info in bend_infodata:
         shape = build_relief_cuts_for_bend(
-            bend_info, max_cut, max_material, edge_offset, profile_wire)
+            bend_info, max_cut, max_material, edge_offset, profile_points)
         if shape is None:
             fallback_edges.append(bend_info.line)
         else:
@@ -221,50 +219,100 @@ def validate_profile_sketch(sketch):
     return True, ""
 
 
-def normalize_profile_sketch(sketch):
-    """Extract the sketch's single wire and rescale it (uniformly, so its
-    shape/proportions are preserved) so that it spans exactly x in [0, 1].
+def _discretize_wire_to_points(wire, curve_samples=24):
+    """Convert `wire` into an ordered list of FreeCAD.Vector points (a
+    polyline approximation): straight edges contribute their exact
+    endpoints (no approximation), curved edges (arcs, splines, ...) are
+    approximated with `curve_samples` points.
+
+    This is deliberately lossy for curved edges, but it means the result
+    is always plain straight-line geometry - see `_place_profile_on_span`
+    for why that matters (SheetMetalNewUnfolder.SketchExtraction.
+    edges_to_sketch_object() only accepts Part::GeomLine / GeomCircle
+    edges; anything else, including a BSplineCurve, raises a RuntimeError
+    when the sketch object gets created).
+
+    Edges are stitched together in wire-traversal order regardless of
+    each individual edge's own start/end orientation.
+    """
+    edges = list(wire.OrderedEdges) if hasattr(wire, "OrderedEdges") else list(wire.Edges)
+    points = []
+    for edge in edges:
+        start = edge.firstVertex().Point
+        end = edge.lastVertex().Point
+        if edge.Curve.TypeId == "Part::GeomLine":
+            edge_points = [start, end]
+        else:
+            edge_points = list(edge.discretize(Number=max(curve_samples, 2)))
+            if edge_points[0].distanceToPoint(end) < edge_points[0].distanceToPoint(start):
+                edge_points.reverse()
+        if points:
+            # Orient this edge's points to continue from the last point
+            # already collected, regardless of the edge's own
+            # start/end direction.
+            if edge_points[0].distanceToPoint(points[-1]) > edge_points[-1].distanceToPoint(points[-1]):
+                edge_points.reverse()
+            if edge_points[0].distanceToPoint(points[-1]) < eps:
+                edge_points = edge_points[1:]
+        points.extend(edge_points)
+    return points
+
+
+def normalize_profile_sketch(sketch, curve_samples=24):
+    """Extract the sketch's single wire as an ordered polyline (see
+    `_discretize_wire_to_points`) and rescale it *along X only* so it
+    spans exactly x in [0, 1].
 
     This is what makes it "tileable": the caller doesn't care about its
-    real-world size, only its shape along X, because it gets stretched to
-    fit each individual cut span - see `_place_profile_on_span`. The
-    wire's Y amplitude is left in the sketch's original real-world units,
-    so features like dogbone/chevron depth stay a fixed physical size
-    regardless of how long an individual cut segment ends up being.
+    real-world X size, only its shape, because it gets stretched to fit
+    each individual cut span - see `_place_profile_on_span`. Y is left
+    untouched, in the sketch's original real-world units, so features
+    like dogbone/chevron depth stay a fixed physical size regardless of
+    how long an individual cut segment ends up being.
 
-    Caller is expected to have already validated the sketch with
-    `validate_profile_sketch`.
+    Returns a list of FreeCAD.Vector points (x in [0, 1], y in the
+    sketch's real-world units, z = 0). Caller is expected to have already
+    validated the sketch with `validate_profile_sketch`.
     """
     wire = sketch.Shape.Wires[0]
-    bbox = wire.BoundBox
-    scale = 1.0 / bbox.XLength if bbox.XLength > eps else 1.0
-    mat = FreeCAD.Matrix()
-    mat.scale(scale, scale, scale)
-    mat.move(FreeCAD.Vector(-bbox.XMin * scale, 0, 0))
-    return wire.transformGeometry(mat)
+    points = _discretize_wire_to_points(wire, curve_samples)
+    xs = [p.x for p in points]
+    x_min, x_max = min(xs), max(xs)
+    x_range = x_max - x_min
+    scale = 1.0 / x_range if x_range > eps else 1.0
+    return [FreeCAD.Vector((p.x - x_min) * scale, p.y, 0.0) for p in points]
 
 
-def _place_profile_on_span(unit_wire, p1, p2):
-    """Stretch `unit_wire` (x in [0, 1], centered on y = 0) along its X
-    axis to span `p1` -> `p2`, then rotate/translate it into place.
+def _place_profile_on_span(unit_points, p1, p2):
+    """Stretch `unit_points` (x in [0, 1], y in real-world units - see
+    `normalize_profile_sketch`) along its X axis to span `p1` -> `p2`,
+    then rotate/translate it into place.
 
-    Only the X axis is stretched; the Y amplitude of the profile stays at
-    its original real-world size (see `normalize_profile_sketch`) so a
+    Only the X axis is stretched; Y is carried over unchanged so a
     dogbone/chevron/etc. keeps a consistent physical depth no matter how
     long the individual cut segment is.
+
+    Builds the result by hand (plain vector math -> Part.LineSegment
+    edges) rather than via Shape.transformGeometry(): OCCT's general
+    (non-uniform) affine curve transform can't represent even a straight
+    Part::GeomLine directly and silently rebuilds it as a
+    Part::GeomBSplineCurve instead, which
+    SketchExtraction.edges_to_sketch_object() then rejects. Doing the
+    placement ourselves guarantees the output is always plain lines.
     """
     span_vec = p2 - p1
     span_len = span_vec.Length
-    if span_len < eps:
+    if span_len < eps or len(unit_points) < 2:
         return None
     direction = span_vec.normalize()
+    perp = FreeCAD.Vector(-direction.y, direction.x, 0.0)  # +90 deg in XY
 
-    scale_mat = FreeCAD.Matrix()
-    scale_mat.scale(span_len, 1.0, 1.0)
-    stretched = unit_wire.transformGeometry(scale_mat)
+    world_points = [p1 + direction * (pt.x * span_len) + perp * pt.y for pt in unit_points]
 
-    angle = math.degrees(math.atan2(direction.y, direction.x))
-    placement = FreeCAD.Placement(p1, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), angle))
-    placed = stretched.copy()
-    placed.Placement = placement
-    return placed
+    edges = []
+    for a, b in zip(world_points, world_points[1:]):
+        if a.distanceToPoint(b) > eps:
+            edges.append(Part.makeLine(a, b))
+    if not edges:
+        return None
+    return Part.makeCompound(edges)

--- a/SheetMetalBendCuts.py
+++ b/SheetMetalBendCuts.py
@@ -1,0 +1,270 @@
+########################################################################
+#
+#  SheetMetalBendCuts.py
+#
+#  Copyright 2026
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2 of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+########################################################################
+"""Geometry helpers for laser "cold bending" / hinge-cutting relief patterns.
+
+This module is a pure post-process of the data the unfolder already
+produces: given a list of straight bend-line edges (as ``BendInfo``-like
+objects exposing a ``.line`` attribute) it produces the *cut* geometry of
+a broken/segmented line along each bend, leaving gaps for the uncut
+material bridges that hold the part together for hand-folding.
+
+Deliberately, this module only depends on ``Part``/``FreeCAD`` primitives
+and a minimal duck-typed ``BendInfo`` (an object with a ``.line``
+Part.Edge attribute). It does not import ``SheetMetalNewUnfolder`` or
+``SheetMetalUnfolder``, and it never touches fold/bend/solid geometry of
+the sheet metal feature tree - it only ever reads a straight edge and
+returns new, unrelated cut edges.
+"""
+
+import math
+
+import FreeCAD
+import Part
+
+eps = 1e-7
+
+# Flip this to True from the Python console (`import SheetMetalBendCuts;
+# SheetMetalBendCuts.DEBUG = True`) to get diagnostic prints from both
+# this module and the calling code in SheetMetalUnfoldCmd.py during the
+# next Unfold recompute.
+DEBUG = False
+
+
+class BareEdgeBendInfo:
+    """Minimal adapter so a plain Part.Edge can be used wherever a
+    BendInfo-like object (only needs a `.line` attribute) is expected.
+
+    Useful for callers (e.g. a future old-unfolder integration) that only
+    have raw bend edges rather than full BendInfo objects from the new
+    unfolder.
+    """
+
+    def __init__(self, edge):
+        self.line = edge
+
+
+###################################################################################################
+# 1. Segmenting a bend line into cut/bridge spans
+###################################################################################################
+
+def segment_bend_line(length, max_cut, max_material, edge_offset):
+    """Return a list of (start, end, is_cut) spans along a 1D line of the
+    given length, alternating cut/bridge, starting and ending with a cut
+    segment, respecting max_cut / max_material and leaving edge_offset
+    untouched at both ends.
+
+    Cut segments are kept as close to `max_cut` as possible; the leftover
+    length is absorbed by the bridges (up to `max_material`). If even the
+    minimum number of bridge-separated cuts would still need bridges
+    longer than `max_material`, more (shorter) cuts are added. If cuts at
+    `max_cut` would already overshoot the usable length, cuts are instead
+    shrunk evenly and bridges collapse to zero length.
+
+    Returns an empty list if the bend line is too short to fit even a
+    single cut segment inside the edge offsets.
+    """
+    if max_cut <= eps:
+        return []
+
+    usable = length - 2.0 * edge_offset
+    if usable <= eps:
+        return []
+
+    if usable <= max_cut + eps:
+        # Whole usable length fits in a single cut segment.
+        return [(edge_offset, edge_offset + usable, True)]
+
+    # Need n >= 2 cut segments with (n - 1) bridges between them.
+    n = 2
+    cut_len = max_cut
+    bridge_len = 0.0
+    while True:
+        bridge_total = usable - n * max_cut
+        if bridge_total <= eps:
+            # Cuts at their maximum length alone would already meet or
+            # exceed the usable length - shrink the cuts evenly instead
+            # and collapse the bridges to zero length.
+            cut_len = usable / n
+            bridge_len = 0.0
+            break
+        bridge_len_candidate = bridge_total / (n - 1)
+        if bridge_len_candidate <= max_material + eps:
+            cut_len = max_cut
+            bridge_len = bridge_len_candidate
+            break
+        n += 1
+
+    spans = []
+    pos = edge_offset
+    for i in range(n):
+        spans.append((pos, pos + cut_len, True))
+        pos += cut_len
+        if i < n - 1:
+            spans.append((pos, pos + bridge_len, False))
+            pos += bridge_len
+    return spans
+
+
+###################################################################################################
+# 2. Turning spans into geometry on a real bend edge
+###################################################################################################
+
+def build_relief_cuts_for_bend(bend_info, max_cut, max_material, edge_offset,
+                                profile_wire=None):
+    """bend_info: object with a `.line` attribute (a straight Part.Edge),
+       e.g. SheetMetalNewUnfolder.BendInfo or BareEdgeBendInfo.
+    profile_wire: optional normalized 2D Part.Wire (see
+                  `normalize_profile_sketch`) or None for a plain
+                  straight cut.
+    Returns a Part.Compound of the *cut* geometry only (bridges are gaps,
+    i.e. no geometry is emitted for them - that's what leaves the
+    material connected), or None if the bend line is too short to fit
+    any relief cut at all (caller should keep the plain solid bend line
+    for that bend instead).
+    """
+    edge = bend_info.line
+    length = edge.Length
+    spans = segment_bend_line(length, max_cut, max_material, edge_offset)
+    if DEBUG:
+        FreeCAD.Console.PrintMessage(
+            f"[BendCuts] bend length={length:.4f} edge midpoint={edge.valueAt(0.5 * (edge.FirstParameter + edge.LastParameter))} "
+            f"-> {len(spans)} span(s): {[(round(s, 3), round(e, 3), c) for s, e, c in spans]}\n")
+    if not spans:
+        return None
+    cut_shapes = []
+    for start, end, is_cut in spans:
+        if not is_cut:
+            continue
+        p1 = edge.valueAt(edge.FirstParameter + start)
+        p2 = edge.valueAt(edge.FirstParameter + end)
+        if profile_wire is None:
+            cut_shapes.append(Part.makeLine(p1, p2))
+        else:
+            placed = _place_profile_on_span(profile_wire, p1, p2)
+            if placed is not None:
+                cut_shapes.append(placed)
+    if not cut_shapes:
+        return None
+    return Part.makeCompound(cut_shapes)
+
+
+def build_relief_cuts(bend_infodata, max_cut, max_material, edge_offset,
+                       profile_wire=None):
+    """Build relief-cut geometry for a whole list of bends at once.
+
+    Returns a tuple (cut_compound, fallback_edges):
+      - cut_compound: Part.Compound of all relief-cut geometry (across
+        every bend that was long enough for the requested pattern).
+      - fallback_edges: list of the original, full-length Part.Edge bend
+        lines for any bend that was too short to fit even a single cut
+        segment inside the requested edge offsets. The caller can render
+        these as plain solid bend lines instead so that short bends are
+        not silently left without any visual/exportable indication.
+    """
+    cut_shapes = []
+    fallback_edges = []
+    for bend_info in bend_infodata:
+        shape = build_relief_cuts_for_bend(
+            bend_info, max_cut, max_material, edge_offset, profile_wire)
+        if shape is None:
+            fallback_edges.append(bend_info.line)
+        else:
+            cut_shapes.append(shape)
+    return Part.makeCompound(cut_shapes), fallback_edges
+
+
+###################################################################################################
+# 3. Custom relief shape from a sketch
+###################################################################################################
+
+def validate_profile_sketch(sketch):
+    """Validate that `sketch` can be used as a bend-relief profile.
+
+    Returns (True, "") if valid, or (False, message) describing why not.
+    """
+    if sketch is None:
+        return False, "no profile sketch selected"
+    if not hasattr(sketch, "Shape") or sketch.Shape is None:
+        return False, "selected object has no usable shape"
+    wires = sketch.Shape.Wires
+    if len(wires) != 1:
+        return False, f"sketch must contain exactly one wire (found {len(wires)})"
+    wire = wires[0]
+    if wire.isClosed():
+        return False, "profile wire must be open (a closed wire can't be tiled along a cut)"
+    bbox = wire.BoundBox
+    if bbox.XLength < eps:
+        return False, "profile wire has zero length along its local X axis"
+    if bbox.ZLength > 1e-3:
+        return False, "profile wire must be planar, drawn flat in the XY plane"
+    return True, ""
+
+
+def normalize_profile_sketch(sketch):
+    """Extract the sketch's single wire and rescale it (uniformly, so its
+    shape/proportions are preserved) so that it spans exactly x in [0, 1].
+
+    This is what makes it "tileable": the caller doesn't care about its
+    real-world size, only its shape along X, because it gets stretched to
+    fit each individual cut span - see `_place_profile_on_span`. The
+    wire's Y amplitude is left in the sketch's original real-world units,
+    so features like dogbone/chevron depth stay a fixed physical size
+    regardless of how long an individual cut segment ends up being.
+
+    Caller is expected to have already validated the sketch with
+    `validate_profile_sketch`.
+    """
+    wire = sketch.Shape.Wires[0]
+    bbox = wire.BoundBox
+    scale = 1.0 / bbox.XLength if bbox.XLength > eps else 1.0
+    mat = FreeCAD.Matrix()
+    mat.scale(scale, scale, scale)
+    mat.move(FreeCAD.Vector(-bbox.XMin * scale, 0, 0))
+    return wire.transformGeometry(mat)
+
+
+def _place_profile_on_span(unit_wire, p1, p2):
+    """Stretch `unit_wire` (x in [0, 1], centered on y = 0) along its X
+    axis to span `p1` -> `p2`, then rotate/translate it into place.
+
+    Only the X axis is stretched; the Y amplitude of the profile stays at
+    its original real-world size (see `normalize_profile_sketch`) so a
+    dogbone/chevron/etc. keeps a consistent physical depth no matter how
+    long the individual cut segment is.
+    """
+    span_vec = p2 - p1
+    span_len = span_vec.Length
+    if span_len < eps:
+        return None
+    direction = span_vec.normalize()
+
+    scale_mat = FreeCAD.Matrix()
+    scale_mat.scale(span_len, 1.0, 1.0)
+    stretched = unit_wire.transformGeometry(scale_mat)
+
+    angle = math.degrees(math.atan2(direction.y, direction.x))
+    placement = FreeCAD.Placement(p1, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), angle))
+    placed = stretched.copy()
+    placed.Placement = placement
+    return placed

--- a/SheetMetalUnfoldCmd.py
+++ b/SheetMetalUnfoldCmd.py
@@ -29,6 +29,7 @@ import sys
 import FreeCAD
 import Part
 
+import SheetMetalBendCuts
 import SheetMetalKfactor
 import SheetMetalTools
 import SheetMetalUnfolder
@@ -73,6 +74,11 @@ smUnfoldDefaultVars = [
     "KFactorStandard",
     "GenerateSketch",
     "SeparateSketchLayers",
+    "GenerateBendCuts",
+    "BendCutMaxMaterial",
+    "BendCutMaxCut",
+    "BendCutEdgeOffset",
+    "BendCutShapeMode",
 ]
 smUnfoldNonSavedDefaultVars = [
     "UnfoldTransparency",
@@ -80,6 +86,7 @@ smUnfoldNonSavedDefaultVars = [
     "InternalColor",
     "BendLineColor",
     "BendLabelColor",
+    "CutSketchColor",
     "ExportType",
 ]
 
@@ -87,6 +94,7 @@ GENSKETCHCOLOR = "#000080"
 OUTLINESKETCHCOLOR = "#c00000"
 BENDLINESKETCHCOLOR = "#ff5733"
 BENDLABELCOLOR = "#33ff33"
+BENDCUTSKETCHCOLOR = "#00c0ff"
 KFACTOR = 0.40
 
 
@@ -136,6 +144,7 @@ class SMUnfold:
         self.InternalColor = OUTLINESKETCHCOLOR
         self.BendLineColor = BENDLINESKETCHCOLOR
         self.BendLabelColor = BENDLABELCOLOR
+        self.CutSketchColor = BENDCUTSKETCHCOLOR
         self.UnfoldTransparency = 0
         self.ExportType = "dxf"
         self.visibleSketches = []
@@ -198,6 +207,42 @@ class SMUnfold:
                 "FontSize",
                 translate("App::Property", "Font size for bend angle labels"),
                 2.0)
+        SheetMetalTools.smAddBoolProperty(obj,
+            "GenerateBendCuts",
+            translate("SheetMetal",
+                "Generate laser bend-relief (hinge) cuts along the bend lines"),
+            False,
+        )
+        SheetMetalTools.smAddLengthProperty(obj,
+                "BendCutMaxMaterial",
+                translate("SheetMetal",
+                    "Maximum length of an uncut material bridge in the relief pattern"),
+                8.0)
+        SheetMetalTools.smAddLengthProperty(obj,
+                "BendCutMaxCut",
+                translate("SheetMetal",
+                    "Maximum length of a single cut segment in the relief pattern"),
+                3.0)
+        SheetMetalTools.smAddLengthProperty(obj,
+                "BendCutEdgeOffset",
+                translate("SheetMetal",
+                    "Margin left uncut at each end of the bend line"),
+                5.0)
+        SheetMetalTools.smAddEnumProperty(obj,
+            "BendCutShapeMode",
+            translate("SheetMetal", "Relief cut profile source"),
+            ["straight", "sketch"],
+            "straight",
+        )
+        SheetMetalTools.smAddProperty(obj,
+            "App::PropertyLink",
+            "BendCutProfileSketch",
+            translate("SheetMetal",
+                "Sketch defining a custom relief cut profile (e.g. dogbone, wave, "
+                "chevron), tiled along each cut segment. Only used when "
+                "'BendCutShapeMode' is 'sketch'"),
+            None,
+        )
         # SheetMetalTools.smAddProperty(
         #     obj,
         #     "App::PropertyBool",
@@ -228,6 +273,30 @@ class SMUnfold:
             if not isVisible:
                 obj.Proxy.visibleSketches = visibleSketches
 
+    def getBendCutProfile(self, obj):
+        """Return the normalized (tileable) relief profile wire to use for
+        bend-relief cuts, or None to use plain straight cuts.
+
+        Never raises: an invalid/missing profile sketch just falls back to
+        straight cuts (with a logged warning), so a recompute never fails
+        because of a bad selection here.
+        """
+        if obj.BendCutShapeMode != "sketch":
+            return None
+        sketch = obj.BendCutProfileSketch
+        if sketch is None:
+            SMLogger.warning(translate("SheetMetal",
+                "Bend relief shape is set to 'From sketch' but no profile "
+                "sketch is selected; using straight cuts instead.\n"))
+            return None
+        valid, msg = SheetMetalBendCuts.validate_profile_sketch(sketch)
+        if not valid:
+            SMLogger.warning(translate("SheetMetal",
+                "Bend relief profile sketch is not usable ({}); using "
+                "straight cuts instead.\n").format(msg))
+            return None
+        return SheetMetalBendCuts.normalize_profile_sketch(sketch)
+
     def newUnfolder(self, obj, baseObject, baseFace):
         """Use new unfolder system."""
         FreeCAD.Console.PrintMessage("Using V2 unfolding system\n")
@@ -245,27 +314,128 @@ class SMUnfold:
 
         sketches = []
         if obj.GenerateSketch and unfolded_shape is not None:
-            if not obj.ShowBendAngles:
-                bend_infodata = []
+            label_infodata = bend_infodata if obj.ShowBendAngles else []
+
+            # Bend-relief cuts are a pure post-process of `bend_infodata`,
+            # computed *before* it gets filtered above for label display
+            # purposes - the two are independent switches. This never
+            # touches `bend_lines`/`unfolded_shape`/fold geometry itself.
+            #
+            # IMPORTANT (coordinate frame): `bend_infodata[i].line` lives
+            # in the "flattened, origin-aligned" frame that `getUnfold()`
+            # aligns everything to internally (call it frame A). The
+            # `bend_lines` *parameter* that `getUnfoldSketches()` expects,
+            # on the other hand, is `bend_lines` as *returned* by
+            # `getUnfold()`, which has already been transformed back into
+            # the raw "in-place" frame (frame B) - `getUnfoldSketches()`
+            # re-aligns frame B to a (newly, independently recomputed)
+            # origin-aligned frame A' via its own `sketch_align_transform`
+            # and applies it once, forward, to whatever it's given in
+            # that parameter. Frame A and frame A' share the same
+            # rotation (both derived from the same root/selected face)
+            # but can differ in translation, since they're computed from
+            # the bounding boxes of two different shapes (the full
+            # unfold's sketch lines vs. just the outer wire re-extracted
+            # from `unfolded_shape`).
+            #
+            # So: geometry already in frame A (like our relief cuts, or
+            # like `bend_labels` below) must *not* be hop through another
+            # forward transform meant for frame-B data, or it gets
+            # transformed twice. `getUnfoldSketches()` itself sidesteps
+            # this for bend labels by pre-applying the *inverse* of its
+            # transform before merging them in, so the later forward pass
+            # cancels back out. We do the same for the merged-sketch
+            # substitution below.
+            bend_lines_for_sketch = bend_lines
+            extra_cut_layer_edges = None
+            if obj.GenerateBendCuts and bend_infodata:
+                profile = self.getBendCutProfile(obj)
+                cut_compound, fallback_edges = SheetMetalBendCuts.build_relief_cuts(
+                    bend_infodata,
+                    obj.BendCutMaxCut.Value,
+                    obj.BendCutMaxMaterial.Value,
+                    obj.BendCutEdgeOffset.Value,
+                    profile,
+                )
+                if fallback_edges:
+                    # Bends too short for the requested pattern keep their
+                    # plain solid bend line instead of being dropped.
+                    cut_compound = Part.makeCompound([cut_compound, Part.makeCompound(fallback_edges)])
+
+                if SheetMetalBendCuts.DEBUG:
+                    FreeCAD.Console.PrintMessage(
+                        f"[BendCuts] bend_infodata: {len(bend_infodata)} bend(s), "
+                        f"lengths={[round(bi.line.Length, 3) for bi in bend_infodata]}\n")
+                    FreeCAD.Console.PrintMessage(
+                        f"[BendCuts] cut_compound (frame A, pre-fix) BoundBox={cut_compound.BoundBox}\n")
+
+                if obj.SeparateSketchLayers:
+                    # Keep the existing dashed "_Sketch_Bends" layer as-is
+                    # and add the cut pattern as its own extra layer, built
+                    # directly (bypassing getUnfoldSketches' internal
+                    # merge/transform), exactly like the existing
+                    # "_Sketch_Bend_Labels" layer already does with its
+                    # own frame-A `bend_labels` data - no extra transform
+                    # needed here.
+                    extra_cut_layer_edges = cut_compound
+                else:
+                    # Single merged sketch: substitute the real cut
+                    # geometry for the plain bend line so the exported
+                    # sketch shows actual segmented cuts, not a solid
+                    # line on top of them. `bend_lines_for_sketch` is
+                    # about to receive one forward alignment transform
+                    # from `getUnfoldSketches()` (meant for frame-B data),
+                    # so pre-cancel it here since our data is already in
+                    # frame A - mirrors how `bend_labels_transformed` is
+                    # built inside `getUnfoldSketches()`.
+                    cut_sketch_profile, _cut_inner, _cut_holes = SheetMetalNewUnfolder.SketchExtraction.extract_manually(
+                        unfolded_shape, root_normal)
+                    merge_align_transform = SheetMetalNewUnfolder.SketchExtraction.move_to_origin(
+                        cut_sketch_profile, sel_face)
+                    bend_lines_for_sketch = cut_compound.transformed(merge_align_transform.inverse())
+
+                    if SheetMetalBendCuts.DEBUG:
+                        FreeCAD.Console.PrintMessage(
+                            f"[BendCuts] merge_align_transform (T)={merge_align_transform}\n")
+                        FreeCAD.Console.PrintMessage(
+                            f"[BendCuts] bend_lines (frame B, unmodified) BoundBox={bend_lines.BoundBox}\n")
+                        FreeCAD.Console.PrintMessage(
+                            f"[BendCuts] cut_compound after T^-1 correction BoundBox="
+                            f"{bend_lines_for_sketch.BoundBox}\n")
+
             sketches = SheetMetalNewUnfolder.getUnfoldSketches(
                 obj.Label,
                 sel_face,
                 unfolded_shape, 
-                bend_lines,
+                bend_lines_for_sketch,
                 root_normal, 
                 obj.UnfoldSketches,
                 obj.SeparateSketchLayers,
                 obj.Proxy.SketchColor,
                 obj.Proxy.BendLineColor,
                 obj.Proxy.InternalColor,
-                bend_infodata=bend_infodata,
+                bend_infodata=label_infodata,
                 bend_label_color=obj.Proxy.BendLabelColor,
                 bend_label_size=obj.FontSize,
             )
+            if extra_cut_layer_edges is not None and extra_cut_layer_edges.Edges:
+                cut_sketch = SheetMetalNewUnfolder.SketchExtraction.edges_to_sketch_object(
+                    extra_cut_layer_edges.Edges,
+                    f"{obj.Label}_Sketch_BendCuts",
+                    obj.UnfoldSketches,
+                    obj.Proxy.CutSketchColor,
+                )
+                sketches.append(cut_sketch)
         return unfolded_shape, sketches
 
     def oldUnfolder(self, obj, baseObject, baseFace):
-        """Use old unfolder system."""
+        """Use old unfolder system.
+
+        Note: Bend-relief cuts (`GenerateBendCuts`) are only supported
+        through the new unfolder, which is the only one that provides
+        per-bend `BendInfo` data. The task panel disables the bend-cuts
+        controls when the old unfolder is active.
+        """
         FreeCAD.Console.PrintMessage("Using V1 unfolding system\n")
         kFactorTable = {1: obj.KFactor}
         if obj.MaterialSheet != "_manual" and obj.MaterialSheet != "_none":
@@ -438,6 +608,12 @@ if SheetMetalTools.isGuiLoaded():
             self.InternalColor = OUTLINESKETCHCOLOR
             self.BendLineColor = BENDLINESKETCHCOLOR
             self.BendLabelColor = BENDLABELCOLOR
+            self.CutSketchColor = BENDCUTSKETCHCOLOR
+            # Bend-relief cuts need per-bend BendInfo data, only available
+            # through the new unfolder. Computed early: `chkSketchChange`
+            # (invoked below as a side effect of `taskConnectCheck`)
+            # depends on it.
+            self.bendCutsAvailable = NewUnfolderAvailable and not SheetMetalTools.use_old_unfolder()
             self.populateMdsList()
             SheetMetalTools.taskConnectSelectionSingle(self.form.pushFace, self.form.txtFace, obj,
                                                        "baseObject", ["Face"])
@@ -445,12 +621,22 @@ if SheetMetalTools.isGuiLoaded():
             SheetMetalTools.taskConnectColor(obj.Proxy, self.form.bendColor, "BendLineColor")
             SheetMetalTools.taskConnectColor(obj.Proxy, self.form.internalColor, "InternalColor")
             SheetMetalTools.taskConnectColor(obj.Proxy, self.form.bendLabelColor, "BendLabelColor")
+            SheetMetalTools.taskConnectColor(obj.Proxy, self.form.cutColor, "CutSketchColor")
             SheetMetalTools.taskConnectCheck(obj, self.form.chkSketch, "GenerateSketch",
                                              self.chkSketchChange)
             SheetMetalTools.taskConnectCheck(obj, self.form.chkSeparate, "SeparateSketchLayers",
                                              self.chkSketchChange)
             SheetMetalTools.taskConnectCheck(obj, self.form.chkAngleLabels, "ShowBendAngles",
                                              self.chkSketchChange)
+            SheetMetalTools.taskConnectCheck(obj, self.form.chkBendCuts, "GenerateBendCuts",
+                                             self.chkBendCutsChange)
+            SheetMetalTools.taskConnectSpin(obj, self.form.maxMaterialDist, "BendCutMaxMaterial")
+            SheetMetalTools.taskConnectSpin(obj, self.form.maxCutDist, "BendCutMaxCut")
+            SheetMetalTools.taskConnectSpin(obj, self.form.cutEdgeOffset, "BendCutEdgeOffset")
+            SheetMetalTools.taskConnectSelectionSingle(self.form.pushCutSketch,
+                                                       self.form.txtCutSketch, obj,
+                                                       "BendCutProfileSketch",
+                                                       ("Sketcher::SketchObject", []))
             SheetMetalTools.taskConnectCheck(obj, self.form.chkManualUpdate, "ManualRecompute",
                                              self.chkManualChanged)
             SheetMetalTools.taskConnectCheck(obj, self.form.chkManualUpdate, "ManualRecompute",
@@ -464,6 +650,18 @@ if SheetMetalTools.isGuiLoaded():
             self.form.availableMds.currentIndexChanged.connect(self.availableMdsChacnge)
             self.form.dxfExport.toggled.connect(self.exportTypeChanged)
             self.form.kfactorAnsi.toggled.connect(self.kfactorStdChanged)
+            self.form.radioSketchCut.toggled.connect(self.cutShapeChanged)
+
+            if obj.BendCutShapeMode == "sketch":
+                self.form.radioSketchCut.setChecked(True)
+            else:
+                self.form.radioStraightCut.setChecked(True)
+
+            if not self.bendCutsAvailable:
+                self.form.chkBendCuts.setChecked(False)
+                self.form.chkBendCuts.setToolTip(translate("SheetMetal",
+                    "Bend relief cuts require the new unfolder (networkx), "
+                    "which is not currently active."))
 
             self.availableMdsChacnge()
             self.chkSketchChange()
@@ -500,8 +698,29 @@ if SheetMetalTools.isGuiLoaded():
             # if len(self.obj.UnfoldSketches) > 0:
             #     FreeCAD.ActiveDocument.recompute()
 
+        def checkBendCutsValid(self):
+            if not (self.form.chkBendCuts.isChecked() and self.form.chkBendCuts.isEnabled()):
+                return True
+            if self.form.radioStraightCut.isChecked():
+                return True
+            sketch = self.obj.BendCutProfileSketch
+            if sketch is None:
+                SheetMetalTools.smWarnDialog(translate("SheetMetal",
+                    "Bend relief shape is set to 'From sketch'.\n"
+                    "Please select a profile sketch, or switch back to 'Straight'."))
+                return False
+            valid, msg = SheetMetalBendCuts.validate_profile_sketch(sketch)
+            if not valid:
+                SheetMetalTools.smWarnDialog(translate("SheetMetal",
+                    "The selected bend relief profile sketch is not usable:\n{}"
+                ).format(msg))
+                return False
+            return True
+
         def accept(self):
             if not self.checkKFactorValid():
+                return False
+            if not self.checkBendCutsValid():
                 return False
             self.recomputeObject(True)
             self.obj.ViewObject.Transparency = self.obj.Proxy.UnfoldTransparency
@@ -549,6 +768,22 @@ if SheetMetalTools.isGuiLoaded():
             unfoldUpdated = not self.obj in SheetMetalTools.smObjectsToRecompute
             exportEnabled = genSketch and len(self.obj.UnfoldSketches) > 0 and unfoldUpdated
             self.form.groupExport.setEnabled(exportEnabled)
+            # Bend cuts only make sense when a sketch is actually being
+            # generated at all - the whole sub-panel collapses with it.
+            # (self.bendCutsAvailable is False when the old unfolder is
+            # active; bend cuts stay disabled regardless of genSketch.)
+            self.form.chkBendCuts.setEnabled(genSketch and self.bendCutsAvailable)
+            self.chkBendCutsChange()
+
+        def chkBendCutsChange(self, _value=None):
+            genCuts = self.form.chkBendCuts.isChecked() and self.form.chkBendCuts.isEnabled()
+            self.form.groupBendCutsBody.setEnabled(genCuts)
+            useSketch = genCuts and self.form.radioSketchCut.isChecked()
+            self.form.groupCutShape.setVisible(useSketch)
+
+        def cutShapeChanged(self, _value=None):
+            self.obj.BendCutShapeMode = "sketch" if self.form.radioSketchCut.isChecked() else "straight"
+            self.chkBendCutsChange()
 
         def exportTypeChanged(self):
             self.obj.Proxy.ExportType = "dxf" if self.form.dxfExport.isChecked() else "svg"
@@ -558,6 +793,8 @@ if SheetMetalTools.isGuiLoaded():
 
         def unfoldPressed(self):
             if not self.checkKFactorValid():
+                return False
+            if not self.checkBendCutsValid():
                 return False
             self.recomputeObject()
             self.chkSketchChange()


### PR DESCRIPTION
The implements an adjustable pattern at the fold line. It offers plain "lines" or custom pattern based on sketches. This is different from the perforation feature, as this always generates rectangles.

Discussion for this feature https://github.com/shaise/FreeCAD_SheetMetal/issues/187